### PR TITLE
remove make clean compile from pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,9 +28,6 @@ jobs:
         pip install numpy
         pip install Cython
         python setup.py install
-    - name: Compile Cython components
-      run: |
-        make clean compile
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
Testing if the workflow works without `make clean compile`