### PR TITLE
update to vivarium-core 0.3.0

### DIFF
--- a/ecoli/composites/ecoli_master.py
+++ b/ecoli/composites/ecoli_master.py
@@ -10,8 +10,8 @@ import json
 import uuid
 from pprint import pformat
 
-from vivarium.core.process import Composer
-from vivarium.core.experiment import pp, Experiment
+from vivarium.core.composer import Composer
+from vivarium.core.engine import pp, Engine
 from vivarium.plots.topology import plot_topology
 
 # sim data
@@ -284,7 +284,7 @@ def test_ecoli(
 
     # make the experiment
     ecoli = ecoli_composer.generate()
-    ecoli_experiment = Experiment({
+    ecoli_experiment = Engine({
         'processes': ecoli.processes,
         'topology': ecoli.topology,
         'initial_state': initial_state,

--- a/ecoli/composites/ecoli_spatial.py
+++ b/ecoli/composites/ecoli_spatial.py
@@ -65,7 +65,7 @@ from scipy import constants
 
 from six.moves import cPickle
 
-from vivarium.core.process import Composer
+from vivarium.core.composer import Composer
 from vivarium.core.composition import simulate_composer
 
 # processes

--- a/ecoli/composites/ecoli_transcription.py
+++ b/ecoli/composites/ecoli_transcription.py
@@ -1,5 +1,5 @@
-from vivarium.core.process import Composer
-from vivarium.core.experiment import Experiment
+from vivarium.core.composer import Composer
+from vivarium.core.engine import Engine
 
 from ecoli.library.sim_data import LoadSimData
 from ecoli.composites.ecoli_master import get_state_from_file, SIM_DATA_PATH
@@ -65,7 +65,7 @@ def test_transcription(total_time=10):
         'topology' : transcription_composite.topology,
         'initial_state' : initial_state
     }
-    transcription_experiment = Experiment(experiment_config)
+    transcription_experiment = Engine(experiment_config)
     transcription_experiment.update(total_time)
 
     data = transcription_experiment.emitter.get_timeseries()

--- a/ecoli/migration/metabolism.py
+++ b/ecoli/migration/metabolism.py
@@ -1,4 +1,4 @@
-from vivarium.core.experiment import Experiment
+from vivarium.core.engine import Engine
 from ecoli.library.sim_data import LoadSimData
 from ecoli.composites.ecoli_master import SIM_DATA_PATH
 from ecoli.processes.metabolism import Metabolism
@@ -54,7 +54,7 @@ def run_metabolism():
     # TODO -- add perturbations to initial_state to test impact on metabolism
 
     metabolism_composite = metabolism_process.generate()
-    experiment = Experiment({
+    experiment = Engine({
         'processes': metabolism_composite['processes'],
         'topology': {metabolism_process.name: topology},
         'initial_state': initial_state

--- a/ecoli/migration/migration_utils.py
+++ b/ecoli/migration/migration_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from vivarium.core.experiment import Experiment
+from vivarium.core.engine import Engine
 
 from ecoli.composites.ecoli_master import get_state_from_file
 
@@ -31,7 +31,7 @@ def run_ecoli_process(
         'processes': {process.name: process},
         'topology': {process.name: topology},
         'initial_state': initial_state}
-    experiment = Experiment(experiment_config)
+    experiment = Engine(experiment_config)
 
     # Get update from process.
     # METHOD 1

--- a/ecoli/migration/polypeptide_elongation.py
+++ b/ecoli/migration/polypeptide_elongation.py
@@ -1,4 +1,4 @@
-from vivarium.core.experiment import Experiment, pf
+from vivarium.core.engine import Engine, pf
 from ecoli.library.sim_data import LoadSimData
 from ecoli.composites.ecoli_master import SIM_DATA_PATH
 from ecoli.migration.migration_utils import run_ecoli_process
@@ -47,7 +47,7 @@ def run_polypeptide_elongation():
         path=f'data/wcecoli_t0.json')
 
     polypeptide_elongation_composite = polypeptide_elongation_process.generate()
-    experiment = Experiment({
+    experiment = Engine({
         'processes': polypeptide_elongation_composite['processes'],
         'topology': {polypeptide_elongation_process.name: PE_TOPOLOGY},
         'initial_state': initial_state

--- a/ecoli/migration/polypeptide_initiation.py
+++ b/ecoli/migration/polypeptide_initiation.py
@@ -1,4 +1,4 @@
-from vivarium.core.experiment import Experiment
+from vivarium.core.engine import Engine
 from ecoli.library.sim_data import LoadSimData
 from ecoli.composites.ecoli_master import SIM_DATA_PATH
 from ecoli.processes.polypeptide_initiation import PolypeptideInitiation
@@ -37,7 +37,7 @@ def test_polypeptide_initiation():
 
     polypeptide_initiation_composite = polypeptide_initiation_process.generate()
 
-    experiment = Experiment({
+    experiment = Engine({
         'processes': polypeptide_initiation_composite['processes'],
         'topology': {polypeptide_initiation_process.name: PI_TOPOLOGY},
         'initial_state': initial_state

--- a/ecoli/migration/rna_degradation.py
+++ b/ecoli/migration/rna_degradation.py
@@ -1,4 +1,4 @@
-from vivarium.core.experiment import Experiment
+from vivarium.core.engine import Engine
 from ecoli.library.sim_data import LoadSimData
 from ecoli.composites.ecoli_master import SIM_DATA_PATH
 from ecoli.processes.rna_degradation import RnaDegradation
@@ -44,7 +44,7 @@ def test_rna_degradation():
 
     rna_degradation_composite = rna_degradation_process.generate()
 
-    experiment = Experiment({
+    experiment = Engine({
         'processes': rna_degradation_composite['processes'],
         'topology': {rna_degradation_process.name: TOPOLOGY},
         'initial_state': initial_state

--- a/ecoli/migration/tf_binding.py
+++ b/ecoli/migration/tf_binding.py
@@ -1,4 +1,4 @@
-from vivarium.core.experiment import Experiment
+from vivarium.core.engine import Engine
 from ecoli.library.sim_data import LoadSimData
 from ecoli.composites.ecoli_master import SIM_DATA_PATH
 from ecoli.processes.tf_binding import TfBinding
@@ -35,7 +35,7 @@ def run_tf_binding():
         path=f'data/wcecoli_t0.json')
 
     tf_binding_composite = tf_binding_process.generate()
-    experiment = Experiment({
+    experiment = Engine({
         'processes': tf_binding_composite['processes'],
         'topology': {tf_binding_process.name: TF_BINDING_TOPOLOGY},
         'initial_state': initial_state

--- a/ecoli/migration/two_component_system.py
+++ b/ecoli/migration/two_component_system.py
@@ -1,4 +1,4 @@
-from vivarium.core.experiment import Experiment
+from vivarium.core.engine import Engine
 from ecoli.library.sim_data import LoadSimData
 from ecoli.composites.ecoli_master import SIM_DATA_PATH
 from ecoli.processes.two_component_system import TwoComponentSystem
@@ -34,7 +34,7 @@ def test_two_component_system():
 
     two_component_system_composite = two_component_system_process.generate()
 
-    experiment = Experiment({
+    experiment = Engine({
         'processes': two_component_system_composite['processes'],
         'topology': {two_component_system_process.name: TOPOLOGY},
         'initial_state': initial_state

--- a/ecoli/processes/mass.py
+++ b/ecoli/processes/mass.py
@@ -13,7 +13,7 @@ from vivarium.core.process import Deriver
 from ecoli.library.schema import mw_schema
 # from wholecell.utils import units
 
-from vivarium.core.experiment import pp
+from vivarium.core.engine import pp
 from vivarium.core.composition import process_in_experiment
 from vivarium.library.units import units
 

--- a/ecoli/processes/two_component_system.py
+++ b/ecoli/processes/two_component_system.py
@@ -10,9 +10,12 @@ import numpy as np
 from vivarium.core.process import Process
 from vivarium.core.composition import simulate_process
 
-from ecoli.library.schema import array_from, array_to, arrays_from, arrays_to, listener_schema, bulk_schema
+from ecoli.library.schema import (
+    array_from, array_to, arrays_from,
+    arrays_to, listener_schema, bulk_schema)
 
 from wholecell.utils import units
+
 
 class TwoComponentSystem(Process):
     name = 'ecoli-two-component-system'

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     long_description_content_type='text/markdown',
     install_requires=[
         'pytest==6.2.4',
-        'vivarium-core==0.2.16',
+        'vivarium-core>=0.3.0',
         'decorator',
         'biopython==1.77',
         'Unum==4.1.4',


### PR DESCRIPTION
This updates vivarium-ecoli to the new Vivarium API, which is introduced to vivarium-core here: https://github.com/vivarium-collective/vivarium-core/pull/84

Once merged, this will require that everyone updates to vivarium-core 0.3.0, since there are some breaking API changes.