### PR TITLE
Add docs tests and pandoc dependency

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
+          sudo apt-get install pandoc
           python -m pip install --upgrade pip wheel
           pip install numpy Cython
           pip install -r requirements.txt

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -1,0 +1,29 @@
+name: Test Documentation
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          sudo apt-get install pandoc
+          python -m pip install --upgrade pip wheel
+          pip install numpy Cython
+          pip install -r requirements.txt
+          python setup.py install
+          pip install -r doc/requirements.txt
+      - name: Build documentation
+        run: |
+          cd doc
+          make html


### PR DESCRIPTION
Building the documentation [failed on GitHub Actions](https://github.com/CovertLab/vivarium-ecoli/runs/3726706943) because `pandoc` is required to process the Jupyter Notebook markdown code. This PR adds a step to install that dependency and adds building the docs as a test so we can catch bugs like this in the future.