### PR TITLE
Second Division Fix

### DIFF
--- a/ecoli/processes/metabolism.py
+++ b/ecoli/processes/metabolism.py
@@ -167,8 +167,10 @@ class Metabolism(Process):
             'listeners': {
                 'mass': {
                     # TODO(Matt): These should not be using a divider. Mass listener should run before metabolism after division.
-                    'cell_mass': {'_default': 0.0},
-                    'dry_mass': {'_default': 0.0}},
+                    'cell_mass': {'_default': 0.0,
+                                  '_divider': 'split'},
+                    'dry_mass': {'_default': 0.0,
+                                 '_divider': 'split'}},
 
                 'fba_results': {
                     'media_id': {'_default': '', '_updater': 'set'},


### PR DESCRIPTION
When daughter cells divided, they used their mother's agent id to represent themselves as they were getting their agent id from `self.config` instead of `config`. `config` has the correct information regarding each daughter cell.