### PR TITLE
Fix Hyper-Replication of Chromosome Domains

### DIFF
--- a/ecoli/processes/chromosome_replication.py
+++ b/ecoli/processes/chromosome_replication.py
@@ -283,7 +283,7 @@ class ChromosomeReplication(PartitionedProcess):
                 '_add': [{
                     'key': str(uuid.uuid1()),
                     'state': {'domain_index': domain_index_new[index]}}
-                    for index in range(n_oriC)],
+                    for index in range(2*n_oriC)],
                 '_delete': [key for key in states['oriCs'].keys()]}
 
             # Add and set attributes of newly created replisomes.


### PR DESCRIPTION
## Problem
Previously, upon initiation of chromosome replication, the number of origins of replication stayed constant. This triggered the chromosome replication code over and over, spawning a large number of chromosome domains.

## Solution
The code managing origins of replication in `chromosome_replication` was corrected to match the behavior of [these lines in wcEcoli](https://github.com/CovertLab/wcEcoli/blob/344bafcc2125b9b3e3c475d16bae63e01d547402/models/ecoli/processes/chromosome_replication.py#L192-#L194). Specifically, the number of origins of replication should double upon chromosome replication, causing the critical mass per origin of replication to fall below the replication threshold for subsequent timesteps.