### PR TITLE
Fix EcoliEngineProcess for reaction-diffusion

### DIFF
--- a/ecoli/composites/ecoli_engine_process.py
+++ b/ecoli/composites/ecoli_engine_process.py
@@ -162,7 +162,7 @@ def run_simulation():
         )
 
         diffusion_schema = environment_composite.processes[
-            'diffusion'].get_schema()
+            'reaction_diffusion'].get_schema()
         multibody_schema = environment_composite.processes[
             'multibody'].get_schema()
         tunnel_out_schemas['fields_tunnel'] = diffusion_schema['fields']


### PR DESCRIPTION
When we added reaction-diffusion in #146, we didn't update the EcoliEngineProcess code to rename the `diffusion` config to `reaction_diffusion`.