### PR TITLE
Fix Metabolism Migration Test

### DIFF
--- a/ecoli/processes/metabolism.py
+++ b/ecoli/processes/metabolism.py
@@ -38,7 +38,10 @@ TOPOLOGY = {
         "kinetics_substrates": ("bulk",),
         "amino_acids": ("bulk",),
         "listeners": ("listeners",),
-        "environment": ("environment",),
+        "environment": {
+            "_path": ("environment",),
+            "exchange": ("exchanges",),
+        },
         "polypeptide_elongation": ("process_state", "polypeptide_elongation"),
         # Non-partitioned count
         "amino_acids_total": ("bulk",),
@@ -153,7 +156,7 @@ class Metabolism(Step):
                 'media_id': {
                     '_default': '',
                     '_updater': 'set'},
-                'exchanges': {
+                'exchange': {
                     element: {'_default': 0}
                     for element in self.model.fba.getExternalMoleculeIDs()},
                 'exchange_data': {
@@ -325,7 +328,7 @@ class Metabolism(Step):
                 for index, metabolite in enumerate(self.model.metaboliteNamesFromNutrients)},
 
             'environment': {
-                'exchanges': {
+                'exchange': {
                     molecule: delta_nutrients[index]
                     for index, molecule in enumerate(fba.getExternalMoleculeIDs())}},
 


### PR DESCRIPTION
In #161, we changed the ports of the metabolism process to use
`exchanges` instead of `exchange` because other processes used
`exchanges`. However, this change broke our metabolism migration tests.
This commit instead uses topology rewiring so that the metabolism
process can still have its port named `exchange`.