### PR TITLE
Give agents from saved states unique seeds

### DIFF
--- a/ecoli/composites/ecoli_engine_process.py
+++ b/ecoli/composites/ecoli_engine_process.py
@@ -216,7 +216,10 @@ def run_simulation(config):
             agent_config['agent_id'] = agent_id
             time_str = config['initial_colony_file'][len('colony_t'):]
             agent_config['seed'] = (
-                agent_config['seed'] + int(float(time_str))) % RAND_MAX
+                agent_config['seed']
+                + int(float(time_str))
+                + int(agent_id, base=2)
+            ) % RAND_MAX
             agent_composer = EcoliEngineProcess(agent_config)
             agent_composite = agent_composer.generate(path=('agents', agent_id))
             if not composite:


### PR DESCRIPTION
Before, when starting from a saved state, each agent got the same random seed, equal to the seed from the config plus the time the state was saved. To make sure each agent has a unique seed, this PR treats the agent ID as a base 2 number and adds its decimal value to the seed.