### PR TITLE
Remove unnecessary conversions and copies

### DIFF
--- a/ecoli/processes/allocator.py
+++ b/ecoli/processes/allocator.py
@@ -8,12 +8,9 @@ process priorities.
 """
 import numpy as np
 from vivarium.core.process import Deriver
-from vivarium.library.dict_utils import make_path_dict
 
 from ecoli.processes.registries import topology_registry
 from ecoli.processes.partition import check_whether_evolvers_have_run
-from ecoli.library.convert_update import convert_numpy_to_builtins
-
 
 # Register default topology for this process, associating it with process name
 NAME = 'allocator'

--- a/ecoli/processes/antibiotics/antibiotic_hydrolysis.py
+++ b/ecoli/processes/antibiotics/antibiotic_hydrolysis.py
@@ -3,7 +3,7 @@ import copy
 from matplotlib import pyplot as plt
 import numpy as np
 
-from vivarium.library.units import units, Quantity
+from vivarium.library.units import units
 from vivarium.library.dict_utils import deep_merge, deep_merge_check
 from vivarium.core.composition import simulate_process
 from vivarium.plots.simulation_output import plot_variables

--- a/ecoli/processes/chromosome_structure.py
+++ b/ecoli/processes/chromosome_structure.py
@@ -19,8 +19,6 @@ from ecoli.library.schema import (
     add_elements, arrays_from, bulk_schema, create_unique_indexes,
     arrays_to, array_to, dict_value_schema, listener_schema)
 from wholecell.utils.polymerize import buildSequences
-from ecoli.library.convert_update import convert_numpy_to_builtins
-
 
 # Register default topology for this process, associating it with process name
 NAME = 'ecoli-chromosome-structure'

--- a/ecoli/processes/complexation.py
+++ b/ecoli/processes/complexation.py
@@ -20,9 +20,7 @@ simulation.
 import numpy as np
 from arrow import StochasticSystem
 
-from vivarium.core.process import Process
 from vivarium.core.composition import simulate_process
-from vivarium.library.dict_utils import deep_merge
 
 from ecoli.library.schema import array_to, bulk_schema
 from ecoli.processes.registries import topology_registry

--- a/ecoli/processes/engine_process.py
+++ b/ecoli/processes/engine_process.py
@@ -63,8 +63,8 @@ import copy
 
 import numpy as np
 from vivarium.core.engine import Engine
-from vivarium.core.process import Process, Step
-from vivarium.core.registry import updater_registry, divider_registry
+from vivarium.core.process import Process
+from vivarium.core.registry import updater_registry
 from vivarium.core.store import DEFAULT_SCHEMA, Store
 from vivarium.library.topology import get_in
 

--- a/ecoli/processes/environment/local_field.py
+++ b/ecoli/processes/environment/local_field.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from vivarium.core.process import Step
-from vivarium.library.units import units, remove_units
+from vivarium.library.units import units
 
 from ecoli.library.lattice_utils import (
     get_bin_site,

--- a/ecoli/processes/environment/lysis.py
+++ b/ecoli/processes/environment/lysis.py
@@ -10,8 +10,8 @@ from scipy import constants
 
 from vivarium.core.process import Step, Process
 from vivarium.core.composer import Composer
-from vivarium.core.engine import Engine, pf
-from vivarium.library.units import units, remove_units
+from vivarium.core.engine import Engine
+from vivarium.library.units import units
 from ecoli.processes.environment.multibody_physics import PI
 from ecoli.processes.environment.local_field import LocalField
 from ecoli.library.lattice_utils import (

--- a/ecoli/processes/equilibrium.py
+++ b/ecoli/processes/equilibrium.py
@@ -10,8 +10,6 @@ that maintains equilibrium.
 
 import numpy as np
 
-from vivarium.library.dict_utils import deep_merge
-
 from ecoli.library.schema import array_from, array_to, bulk_schema
 from ecoli.processes.registries import topology_registry
 from ecoli.processes.partition import PartitionedProcess

--- a/ecoli/processes/listeners/mRNA_counts.py
+++ b/ecoli/processes/listeners/mRNA_counts.py
@@ -9,7 +9,6 @@ from ecoli.library.schema import arrays_from, dict_value_schema
 from vivarium.core.process import Step
 
 from ecoli.processes.registries import topology_registry
-from ecoli.library.convert_update import convert_numpy_to_builtins
 
 
 NAME = 'mRNA_counts_listener'

--- a/ecoli/processes/listeners/mass_listener.py
+++ b/ecoli/processes/listeners/mass_listener.py
@@ -8,13 +8,9 @@ Represents the total cellular mass.
 
 import numpy as np
 from vivarium.core.process import Deriver
-from vivarium.library.units import units
-from ecoli.library.schema import bulk_schema, arrays_from, array_from, dict_value_schema, submass_schema
-
-from vivarium.core.engine import pp
+from ecoli.library.schema import bulk_schema, array_from, dict_value_schema
 
 from ecoli.processes.registries import topology_registry
-from ecoli.library.convert_update import convert_numpy_to_builtins
 
 # Register default topology for this process, associating it with process name
 NAME = 'ecoli-mass-listener'

--- a/ecoli/processes/listeners/monomer_counts.py
+++ b/ecoli/processes/listeners/monomer_counts.py
@@ -9,7 +9,6 @@ from ecoli.library.schema import bulk_schema, array_from
 from vivarium.core.process import Step
 
 from ecoli.processes.registries import topology_registry
-from ecoli.library.convert_update import convert_numpy_to_builtins
 
 
 NAME = 'monomer_counts_listener'

--- a/ecoli/processes/metabolism.py
+++ b/ecoli/processes/metabolism.py
@@ -22,7 +22,6 @@ from vivarium.core.process import Step
 
 from ecoli.processes.registries import topology_registry
 from ecoli.processes.partition import check_whether_evolvers_have_run
-from ecoli.library.convert_update import convert_numpy_to_builtins
 from ecoli.library.schema import bulk_schema, array_from
 from wholecell.utils import units
 from wholecell.utils.random import stochasticRound

--- a/ecoli/processes/partition.py
+++ b/ecoli/processes/partition.py
@@ -15,15 +15,11 @@ which reads the requests and allocates molecular counts for the evolve_state.
 """
 import abc
 import copy
-import os
-import pickle
 
-import numpy as np
 from vivarium.core.process import Step, Process
-from vivarium.library.dict_utils import deep_merge, make_path_dict
+from vivarium.library.dict_utils import deep_merge
 
 from ecoli.processes.registries import topology_registry
-from ecoli.library.convert_update import convert_numpy_to_builtins
 
 
 def check_whether_evolvers_have_run(evolvers_ran, proc_name):

--- a/ecoli/processes/polypeptide_elongation.py
+++ b/ecoli/processes/polypeptide_elongation.py
@@ -20,7 +20,6 @@ from wholecell.utils.random import stochasticRound
 from wholecell.utils import units
 
 # vivarium imports
-from vivarium.core.process import Process
 from vivarium.core.composition import simulate_process
 from vivarium.library.dict_utils import deep_merge
 from vivarium.plots.simulation_output import plot_variables

--- a/ecoli/processes/polypeptide_initiation.py
+++ b/ecoli/processes/polypeptide_initiation.py
@@ -348,23 +348,23 @@ def test_polypeptide_initiation():
             '30S': 2000,
             '50S': 3000},
         'RNA': {
-            0: {
+            '0': {
                 'TU_index': 0,
                 'can_translate': True,
                 'unique_index': 0},
-            1: {
+            '1': {
                 'TU_index': 0,
                 'can_translate': False,
                 'unique_index': 1},
-            2: {
+            '2': {
                 'TU_index': 1,
                 'can_translate': True,
                 'unique_index': 2},
-            3: {
+            '3': {
                 'TU_index': 2,
                 'can_translate': True,
                 'unique_index': 3},
-            4: {
+            '4': {
                 'TU_index': 2,
                 'can_translate': True,
                 'unique_index': 4}}}

--- a/ecoli/processes/protein_degradation.py
+++ b/ecoli/processes/protein_degradation.py
@@ -13,9 +13,7 @@ TODO:
 
 import numpy as np
 
-from vivarium.core.process import Process
 from vivarium.core.composition import simulate_process
-from vivarium.library.dict_utils import deep_merge
 
 from ecoli.library.data_predicates import (
     monotonically_increasing, monotonically_decreasing, all_nonnegative)

--- a/ecoli/processes/rna_degradation.py
+++ b/ecoli/processes/rna_degradation.py
@@ -45,7 +45,6 @@ import numpy as np
 from ecoli.library.schema import (
     array_from, array_to, arrays_from, arrays_to, dict_value_schema, listener_schema, bulk_schema, array_to_nonzero)
 
-from wholecell.utils.constants import REQUEST_PRIORITY_DEGRADATION
 from wholecell.utils import units
 from six.moves import range, zip
 

--- a/ecoli/processes/spatiality/spatial_geometry.py
+++ b/ecoli/processes/spatiality/spatial_geometry.py
@@ -29,7 +29,7 @@ from vivarium.core.composition import (
     simulate_process,
     PROCESS_OUT_DIR,
 )
-from ecoli.library.schema import array_to, array_from
+from ecoli.library.schema import array_from
 
 
 NAME = 'spatial_geometry'

--- a/ecoli/processes/struct_array_demo.py
+++ b/ecoli/processes/struct_array_demo.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from vivarium.core.composition import simulate_process
 from vivarium.core.process import Process
 
-from ecoli.library.schema import add_elements, array_from
+from ecoli.library.schema import array_from
 
 
 def dict_value_updater(current, update):

--- a/ecoli/processes/two_component_system.py
+++ b/ecoli/processes/two_component_system.py
@@ -11,9 +11,6 @@ and back in response to counts of ligand stimulants.
 
 import numpy as np
 
-from vivarium.core.process import Process
-from vivarium.library.dict_utils import deep_merge
-
 from ecoli.library.schema import (
     array_from, array_to, bulk_schema)
 


### PR DESCRIPTION
The conversions from Numpy to built-ins were designed to support process parallelization and are no longer needed. I am not sure what the `deepcopy` in `Evolver.next_update()` is for but removing it significantly improves performance.