### PR TITLE
Fix pytest imports

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,4 +37,4 @@ jobs:
         make clean compile
     - name: Test with pytest
       run: |
-        pytest --cov=ecoli -m 'not (noci or master)'
+        python -m pytest --cov=ecoli -m 'not (noci or master)'

--- a/.github/workflows/pytest_master.yml
+++ b/.github/workflows/pytest_master.yml
@@ -30,4 +30,4 @@ jobs:
         make clean compile
     - name: Test with pytest
       run: |
-        pytest --cov=ecoli -m master
+        python -m pytest --cov=ecoli -m master


### PR DESCRIPTION
Use `python -m pytest` instead of just `pytest` because `python` adds
the current directory to PYTHONPATH.