### PR TITLE
Option to Skip ParCa in Workflows

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -38,8 +38,10 @@ jobs:
         echo "PYTHONPATH=." >> $GITHUB_ENV
     - name: Test ParCa reproducibility
       run: |
-        python runscripts/parca.py -c 3 -o out/parca_1
-        python runscripts/parca.py -c 3 -o out/parca_2
+        python runscripts/parca.py --config ecoli/composites/ecoli_configs/run_parca.json \
+            -c 3 -o out/parca_1
+        python runscripts/parca.py --config ecoli/composites/ecoli_configs/run_parca.json \
+            -c 3 -o out/parca_2
         python runscripts/debug/compare_pickles.py out/parca_1/kb out/parca_2/kb
     - name: Test simulation reproducibility
       run: |

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -88,6 +88,12 @@ Configuration options for the ParCa are all located in a dictionary under the
 - ``variable_elongation_translation``: If True, enable variable elongation
   for translation.
 
+.. note::
+  If the top-level ``sim_data_path`` option is not null, the ParCa is skipped
+  in favor of the pickled simulation data at the specified path. This applies
+  regardless of whether running with :py:mod:`runscripts.workflow` or
+  :py:mod:`runscripts.parca`.
+
 .. _variants:
 
 --------

--- a/ecoli/analysis/multigeneration/new_gene_counts.py
+++ b/ecoli/analysis/multigeneration/new_gene_counts.py
@@ -64,7 +64,7 @@ def plot(
         cast(int, mRNA_idx_dict.get(mRNA_id)) for mRNA_id in new_gene_mRNA_ids
     ]
 
-    # Extract proein indexes for each new gene
+    # Extract protein indexes for each new gene
     monomer_idx_dict = {
         monomer: i
         for i, monomer in enumerate(

--- a/ecoli/composites/ecoli_configs/cloud.json
+++ b/ecoli/composites/ecoli_configs/cloud.json
@@ -3,9 +3,9 @@
     "total_time": 23100,
     "divide": true,
     "emitter" : "database",
-    "emitter_arg": [
-        ["host", "10.138.0.75:27017"],
-        ["emit_limit", 4100000]
-    ],
+    "emitter_arg": {
+        "host": "10.138.0.75:27017",
+        "emit_limit": 4100000
+    },
     "parallel": true
 }

--- a/ecoli/composites/ecoli_configs/new_cloud.json
+++ b/ecoli/composites/ecoli_configs/new_cloud.json
@@ -1,9 +1,7 @@
 {
-    "emitter" : {
-        "type": "parquet",
-        "config": {
-            "out_uri": "Create a Cloud Storage bucket and put its URI here."
-        }
+    "emitter": "parquet",
+    "emitter_arg": {
+        "out_uri": "Create a Cloud Storage bucket and put its URI here."
     },
     "gcloud": {
         "build_runtime_image": "False by default, whether to build new Docker image for runtime dependencies (only necessary when dependencies change)",

--- a/ecoli/composites/ecoli_configs/run_parca.json
+++ b/ecoli/composites/ecoli_configs/run_parca.json
@@ -1,0 +1,3 @@
+{
+    "sim_data_path": null
+}

--- a/ecoli/composites/ecoli_configs/test.json
+++ b/ecoli/composites/ecoli_configs/test.json
@@ -7,8 +7,8 @@
     "generations": 10,
     "n_init_sims": 4,
     "single_daughters": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "out"
     },
     "variants": {

--- a/ecoli/composites/ecoli_configs/test_installation.json
+++ b/ecoli/composites/ecoli_configs/test_installation.json
@@ -8,8 +8,8 @@
     "generations": 1,
     "n_init_sims": 1,
     "single_daughters": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "out"
     },
     "analysis_options": {

--- a/ecoli/composites/ecoli_configs/test_installation.json
+++ b/ecoli/composites/ecoli_configs/test_installation.json
@@ -4,6 +4,7 @@
     "parca_options": {
         "cpus": 4
     },
+    "sim_data_path": null,
     "generations": 1,
     "n_init_sims": 1,
     "single_daughters": true,

--- a/ecoli/composites/ecoli_configs/two_generations.json
+++ b/ecoli/composites/ecoli_configs/two_generations.json
@@ -7,8 +7,8 @@
     "generations": 2,
     "n_init_sims": 1,
     "single_daughters": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "out"
     },
     "analysis_options": {

--- a/ecoli/experiments/ecoli_engine_process.py
+++ b/ecoli/experiments/ecoli_engine_process.py
@@ -352,7 +352,7 @@ def run_simulation(config):
 
     experiment_id = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S_%f%z")
     emitter_config = {"type": config["emitter"]}
-    for key, value in config["emitter_arg"]:
+    for key, value in config["emitter_arg"].items():
         emitter_config[key] = value
     base_config = {
         "agent_id": config["agent_id"],

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -369,7 +369,8 @@ class SimConfig:
         updates config.
         """
         args = self.parser.parse_args()
-        args.emitter_arg = parse_key_value_args(args.emitter_arg)
+        if args.emitter_arg is not None:
+            args.emitter_arg = parse_key_value_args(args.emitter_arg)
         # First load in a configuration file, if one was specified.
         config_path = getattr(args, "config", None)
         if config_path:

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -784,7 +784,7 @@ class EcoliSim:
         if isinstance(self.emitter, str):
             self.emitter_config = {"type": self.emitter}
             if self.emitter_arg is not None:
-                for key, value in self.emitter_arg:
+                for key, value in self.emitter_arg.items():
                     self.emitter_config[key] = value
             if self.emitter == "parquet":
                 if ("out_dir" not in self.emitter_config) and (

--- a/ecoli/experiments/tet_amp_sim.py
+++ b/ecoli/experiments/tet_amp_sim.py
@@ -87,7 +87,10 @@ def run_sim(
             config["save_times"] = [11550]
         config["total_time"] = runtime
     if cloud:
-        config["emitter_arg"] = [["host", "10.138.0.75:27017"], ["emit_limit", 5000000]]
+        config["emitter_arg"] = {
+            "host": "10.138.0.75:27017",
+            "emit_limit": 5000000
+        }
 
     run_simulation(config)
 

--- a/runscripts/analysis.py
+++ b/runscripts/analysis.py
@@ -183,15 +183,11 @@ def main():
         config_file = args.config
         with open(os.path.join(args.config), "r") as f:
             SimConfig.merge_config_dicts(config, json.load(f))
-    # Merge all emitter options under emitter_arg into emitter
-    if config["emitter_arg"] is not None:
-        for key, value in config["emitter_arg"].items():
-            config["emitter"][key] = value
-    if "out_uri" not in config["emitter"]:
-        out_uri = os.path.abspath(config["emitter"]["out_dir"])
+    if "out_uri" not in config["emitter_arg"]:
+        out_uri = os.path.abspath(config["emitter_arg"]["out_dir"])
         gcs_bucket = True
     else:
-        out_uri = config["emitter"]["out_uri"]
+        out_uri = config["emitter_arg"]["out_uri"]
         assert (
             parse.urlparse(out_uri).scheme == "gcs"
             or parse.urlparse(out_uri).scheme == "gs"

--- a/runscripts/analysis.py
+++ b/runscripts/analysis.py
@@ -183,6 +183,10 @@ def main():
         config_file = args.config
         with open(os.path.join(args.config), "r") as f:
             SimConfig.merge_config_dicts(config, json.load(f))
+    # Merge all emitter options under emitter_arg into emitter
+    if config["emitter_arg"] is not None:
+        for key, value in config["emitter_arg"].items():
+            config["emitter"][key] = value
     if "out_uri" not in config["emitter"]:
         out_uri = os.path.abspath(config["emitter"]["out_dir"])
         gcs_bucket = True
@@ -288,7 +292,7 @@ def main():
     conn = create_duckdb_conn(out_uri, gcs_bucket, config.get("n_cpus"))
     history_sql, config_sql = get_dataset_sql(out_uri)
     # If no explicit analysis type given, run all types in config JSON
-    if config["analysis_types"] is None:
+    if "analysis_types" not in config:
         config["analysis_types"] = [
             analysis_type for analysis_type in ANALYSIS_TYPES if analysis_type in config
         ]

--- a/runscripts/create_variants.py
+++ b/runscripts/create_variants.py
@@ -268,8 +268,13 @@ def main():
         type=str,
         help="Path to folder where variant sim_data and metadata are written.",
     )
-    config = SimConfig(parser=parser)
-    config.update_from_cli()
+    args = parser.parse_args()
+    with open(default_config, "r") as f:
+        config = json.load(f)
+    if args.config is not None:
+        with open(os.path.join(args.config), "r") as f:
+            SimConfig.merge_config_dicts(config, json.load(f))
+    SimConfig.merge_config_dicts(config, vars(args))
 
     print("Loading sim_data...")
     with open(os.path.join(config["kb"], "simData.cPickle"), "rb") as f:

--- a/runscripts/jenkins/configs/ecoli-anaerobic.json
+++ b/runscripts/jenkins/configs/ecoli-anaerobic.json
@@ -11,8 +11,8 @@
     "d_period_division": false,
     "mechanistic_replisome": true,
     "mass_distribution": false,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {

--- a/runscripts/jenkins/configs/ecoli-glucose-minimal.json
+++ b/runscripts/jenkins/configs/ecoli-glucose-minimal.json
@@ -3,8 +3,8 @@
     "single_daughters": true,
     "generations": 16,
     "fail_at_total_time": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -3,8 +3,8 @@
     "single_daughters": true,
     "generations": 4,
     "fail_at_total_time": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "parca_options": {

--- a/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
+++ b/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
@@ -10,8 +10,8 @@
     "aa_supply_in_charging": false,
     "d_period_division": false,
     "mechanistic_replisome": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {

--- a/runscripts/jenkins/configs/ecoli-no-operons.json
+++ b/runscripts/jenkins/configs/ecoli-no-operons.json
@@ -3,8 +3,8 @@
     "single_daughters": true,
     "generations": 4,
     "fail_at_total_time": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "parca_options": {

--- a/runscripts/jenkins/configs/ecoli-superhelical-density.json
+++ b/runscripts/jenkins/configs/ecoli-superhelical-density.json
@@ -4,8 +4,8 @@
     "generations": 4,
     "fail_at_total_time": true,
     "superhelical_density": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {

--- a/runscripts/jenkins/configs/ecoli-with-aa.json
+++ b/runscripts/jenkins/configs/ecoli-with-aa.json
@@ -3,8 +3,8 @@
     "single_daughters": true,
     "generations": 8,
     "fail_at_total_time": true,
-    "emitter" : {
-        "type": "parquet",
+    "emitter": "parquet",
+    "emitter_arg": {
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -30,6 +30,7 @@ profiles {
         process.maxRetries = 1
         // Check Google Cloud latest spot pricing / performance
         process.machineType = 't2d-standard-1'
+        workflow.failOnIgnore = true
     }
     sherlock {
         process.memory = {
@@ -78,10 +79,12 @@ profiles {
         // Write out job status to log file less frequently
         // than we check queue status (log correct and latest status)
         executor.dumpInterval = '6 min'
+        workflow.failOnIgnore = true
     }
     standard {
         process.executor = 'local'
         params.projectRoot = "${launchDir}"
         params.publishDir = "PUBLISH_DIR"
+        workflow.failOnIgnore = true
     }
 }

--- a/runscripts/parca.py
+++ b/runscripts/parca.py
@@ -183,10 +183,11 @@ def main():
     SimConfig.merge_config_dicts(parca_options, cli_options)
     # If config defines a sim_data_path, skip ParCa
     if config["sim_data_path"] is not None:
-        if not os.path.exists(parca_options["outdir"]):
-            os.makedirs(parca_options["outdir"])
+        out_kb = os.path.join(parca_options["outdir"], "kb")
+        if not os.path.exists(out_kb):
+            os.makedirs(out_kb)
         print(f"{time.ctime()}: Skipping ParCa. Using {config['sim_data_path']}")
-        shutil.copy(config["sim_data_path"], parca_options["outdir"])
+        shutil.copy(config["sim_data_path"], out_kb)
     else:
         run_parca(parca_options)
 

--- a/runscripts/parca.py
+++ b/runscripts/parca.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import os
 import pickle
+import shutil
 import time
 
 from ecoli.composites.ecoli_configs import CONFIG_DIR_PATH
@@ -180,7 +181,14 @@ def main():
     cli_options.pop("config")
     parca_options = config.pop("parca_options")
     SimConfig.merge_config_dicts(parca_options, cli_options)
-    run_parca(parca_options)
+    # If config defines a sim_data_path, skip ParCa
+    if config["sim_data_path"] is not None:
+        if not os.path.exists(parca_options["outdir"]):
+            os.makedirs(parca_options["outdir"])
+        print(f"{time.ctime()}: Skipping ParCa. Using {config['sim_data_path']}")
+        shutil.copy(config["sim_data_path"], parca_options["outdir"])
+    else:
+        run_parca(parca_options)
 
 
 if __name__ == "__main__":

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -289,10 +289,13 @@ def main():
 
     # Resolve output directory
     if "out_uri" not in config["emitter"]:
-        out_uri = os.path.abspath(config["emitter"]["out_dir"])
-        config["emitter"]["out_dir"] = out_uri
+        out_uri = os.path.abspath(config["emitter_arg"]["out_dir"])
+        config["emitter_arg"]["out_dir"] = out_uri
     else:
-        out_uri = config["emitter"]["out_uri"]
+        out_uri = config["emitter_arg"]["out_uri"]
+    # Resolve sim_data_path if provided
+    if config["sim_data_path"] is not None:
+        config["sim_data_path"] = os.path.abspath(config["sim_data_path"])
     filesystem, outdir = fs.FileSystem.from_uri(out_uri)
     outdir = os.path.join(outdir, experiment_id, "nextflow")
     out_uri = os.path.join(out_uri, experiment_id, "nextflow")


### PR DESCRIPTION
Users can now specify the ``sim_data_path`` top-level config JSON option to skip the ParCa when running a workflow.

This PR also fixes bugs with the ``emitter_arg`` config option.