### PR TITLE
More bug fixes

### DIFF
--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -95,11 +95,10 @@ Configuration options for the ParCa are all located in a dictionary under the
   :py:mod:`runscripts.parca`.
 
 .. warning::
-  If running the ParCa (:py:mod:`runscripts.parca`) and simulation
-  (:py:mod:`ecoli.experiments.ecoli_master_sim`) manually instead of as part of
-  a workflow (:py:mod:`runscripts.workflow`), you must create two config JSON
-  files: one for the ParCa with a null ``sim_data_path`` and some ``outdir``
-  (described above in this section) and one for the simulation with
+  If running :py:mod:`runscripts.parca` and :py:mod:`ecoli.experiments.ecoli_master_sim`
+  manually instead of using :py:mod:`runscripts.workflow`, you must create two config JSON
+  files: one for the ParCa with a null ``sim_data_path`` and an ``outdir``
+  as described above and one for the simulation with
   ``sim_data_path`` set to ``{outdir}/kb/simData.cPickle``.
 
 .. _variants:
@@ -670,7 +669,7 @@ the output directory specified via ``out_dir`` or ``out_uri`` under the
           breakpoints set in the relevant code (``import ipdb; ipdb.set_trace()``)
           for debugging.
 
-.. note::
+.. tip::
   To save space, you can safely delete ``nextflow_workdirs`` after you are finished
   troubleshooting a particular workflow.
 

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -94,6 +94,14 @@ Configuration options for the ParCa are all located in a dictionary under the
   regardless of whether running with :py:mod:`runscripts.workflow` or
   :py:mod:`runscripts.parca`.
 
+.. warning::
+  If running the ParCa (:py:mod:`runscripts.parca`) and simulation
+  (:py:mod:`ecoli.experiments.ecoli_master_sim`) manually instead of as part of
+  a workflow (:py:mod:`runscripts.workflow`), you must create two config JSON
+  files: one for the ParCa with a null ``sim_data_path`` and some ``outdir``
+  (described above in this section) and one for the simulation with
+  ``sim_data_path`` set to ``{outdir}/kb/simData.cPickle``.
+
 .. _variants:
 
 --------

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -673,3 +673,60 @@ the output directory specified via ``out_dir`` or ``out_uri`` under the
 .. note::
   To save space, you can safely delete ``nextflow_workdirs`` after you are finished
   troubleshooting a particular workflow.
+
+
+.. _troubleshooting:
+
+---------------
+Troubleshooting
+---------------
+
+To troubleshoot a workflow that was run with :py:mod:`runscripts.workflow`, you can
+either inspect the HTML execution report ``{experiment ID}_report.html`` described
+in :ref:`output` (nice summary and UI) or use the ``nextflow log`` command
+(more flexible and efficient).
+
+HTML Report
+===========
+
+Click "Tasks" in the top bar or scroll to the bottom of the page. Filter for failed
+jobs by putting "failed" into the search bar. Find the work directory (``workdir`` column)
+for each job. Navigate to the work directory for each failed job and
+inspect ``.command.out`` (``STDOUT``), ``.command.err`` (``STDERR``), and
+``.command.log`` (both) files.
+
+CLI
+===
+
+Run ``nextflow log`` in the same directory in which you launched
+the workflow to get the workflow name (should be of the form
+``{adjective}_{famous last name}``). Use the ``-f`` and ``-F``
+flags of ``nextflow log`` to show and filter the information that
+you would like to see (``nextflow log -help`` for more info).
+
+Among the fields that can be shown with ``-f`` are the ``stderr``,
+``stdout``, and ``log``. This allows you to automatically retrieve
+relevant output for all failed jobs in one go instead of manually
+navigating to work directories and opening the relevant text files.
+
+For more information about ``nextflow log``, see the
+`official documentation <https://www.nextflow.io/docs/latest/reports.html#reports>`_.
+For a description of some fields (non-exhaustive) that can be specified with
+``-f``, refer to `this section <https://www.nextflow.io/docs/latest/reports.html#trace-fields>`_
+of the official documentation.
+
+As an example, to see the name, stderr, and workdir for all failed jobs
+in a workflow called ``agitated_mendel``::
+
+  nextflow log agitated_mendel -f name,stderr,workdir -F "status == 'FAILED'"
+
+
+Test Fixes
+==========
+
+After identifying the issue and applying fixes, you can test a failed job
+in isolation by invoking ``bash .command.run`` inside the work
+directory for that job. Once you have addressed all issues,
+you relaunch the workflow by navigating back to the directory in which you
+originally started the workflow and issuing the same command with the
+added ``--resume`` option (see :ref:`fault_tolerance`).

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -669,3 +669,7 @@ the output directory specified via ``out_dir`` or ``out_uri`` under the
           or ``{experiment ID}_report.html``) and run ``bash .command.sh`` with
           breakpoints set in the relevant code (``import ipdb; ipdb.set_trace()``)
           for debugging.
+
+.. note::
+  To save space, you can safely delete ``nextflow_workdirs`` after you are finished
+  troubleshooting a particular workflow.

--- a/ecoli/library/initial_conditions.py
+++ b/ecoli/library/initial_conditions.py
@@ -20,7 +20,12 @@ from wholecell.utils.fitting import (
     masses_and_counts_for_homeostatic_target,
     normalize,
 )
-from wholecell.utils.mc_complexation import mccFormComplexesWithPrebuiltMatrices
+try:
+    from wholecell.utils.mc_complexation import mccFormComplexesWithPrebuiltMatrices
+except ImportError as exc:
+    raise RuntimeError(
+        "Failed to import Cython module. Try running 'make clean compile'."
+    ) from exc
 from wholecell.utils.polymerize import computeMassIncrease
 from wholecell.utils.random import stochasticRound
 

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -762,7 +762,7 @@ class ParquetEmitter(Emitter):
             unified_schema, unified_schema_path, filesystem=self.filesystem
         )
         experiment_schema_path = os.path.join(
-            self.outdir, "history", self.experiment_id, EXPERIMENT_SCHEMA_SUFFIX
+            self.outdir, self.experiment_id, "history", EXPERIMENT_SCHEMA_SUFFIX
         )
         self.filesystem.create_dir(os.path.dirname(experiment_schema_path))
         pq.write_metadata(

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -849,7 +849,7 @@ class ParquetEmitter(Emitter):
             # create new folder for config / simulation output
             try:
                 self.filesystem.delete_dir(os.path.dirname(outfile))
-            except FileNotFoundError:
+            except (FileNotFoundError, OSError):
                 pass
             self.filesystem.create_dir(os.path.dirname(outfile))
             self.executor.submit(
@@ -867,7 +867,7 @@ class ParquetEmitter(Emitter):
             )
             try:
                 self.filesystem.delete_dir(history_outdir)
-            except FileNotFoundError:
+            except (FileNotFoundError, OSError):
                 pass
             self.filesystem.create_dir(history_outdir)
             return

--- a/reconstruction/ecoli/dataclasses/process/complexation.py
+++ b/reconstruction/ecoli/dataclasses/process/complexation.py
@@ -4,7 +4,12 @@ SimulationData for the Complexation process
 
 import numpy as np
 from wholecell.utils import units
-from wholecell.utils.mc_complexation import mccBuildMatrices
+try:
+    from wholecell.utils.mc_complexation import mccBuildMatrices
+except ImportError as exc:
+    raise RuntimeError(
+        "Failed to import Cython module. Try running 'make clean compile'."
+    ) from exc
 
 
 class ComplexationError(Exception):

--- a/runscripts/container/build-runtime.sh
+++ b/runscripts/container/build-runtime.sh
@@ -3,7 +3,7 @@
 # image with requirements.txt installed. If using Cloud Build, store the
 # built image in the "vecoli" folder in the Google Artifact Registry.
 #
-# ASSUMES: The current working dir is the vivarium-ecoli/ project root.
+# ASSUMES: The current working dir is the vEcoli/ project root.
 
 set -eu
 

--- a/runscripts/container/build-runtime.sh
+++ b/runscripts/container/build-runtime.sh
@@ -36,8 +36,13 @@ if [ "$RUN_LOCAL" = true ]; then
     echo "=== Locally building WCM runtime Docker Image: ${RUNTIME_IMAGE} ==="
     docker build -f runscripts/container/runtime/Dockerfile -t "${WCM_RUNTIME}" .
 else
-    PROJECT="$(gcloud config get-value core/project)"
-    REGION=$(gcloud config get compute/region)
+    PROJECT=$(curl -H "Metadata-Flavor: Google" \
+      "http://metadata.google.internal/computeMetadata/v1/project/project-id" |
+      cut '-d/' -f4)
+    REGION=$(curl -H "Metadata-Flavor: Google" \
+      "http://metadata.google.internal/computeMetadata/v1/instance/zone" |
+      awk -F'/' '{print $NF}' | 
+      sed 's/-[a-z]$//')
     TAG="${REGION}-docker.pkg.dev/${PROJECT}/vecoli/${RUNTIME_IMAGE}"
     echo "=== Cloud-building WCM runtime Docker Image: ${TAG} ==="
     echo $TAG

--- a/runscripts/container/build-wcm.sh
+++ b/runscripts/container/build-wcm.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 # Use Google Cloud Build or local Docker install to build a personalized image
-# with current state of the vivarium-ecoli repo. If using Cloud Build, store
+# with current state of the vEcoli repo. If using Cloud Build, store
 # the built image in the "vecoli" folder in the Google Artifact Registry.
 #
-# ASSUMES: The current working dir is the vivarium-ecoli/ project root.
+# ASSUMES: The current working dir is the vEcoli/ project root.
 
 set -eu
 

--- a/runscripts/container/build-wcm.sh
+++ b/runscripts/container/build-wcm.sh
@@ -50,8 +50,10 @@ if [ "$RUN_LOCAL" = true ]; then
 else
     echo "=== Cloud-building WCM code Docker Image ${WCM_IMAGE} on ${RUNTIME_IMAGE} ==="
     echo "=== git hash ${GIT_HASH}, git branch ${GIT_BRANCH} ==="
-    PROJECT_ID=$(gcloud config get project)
-    REGION=$(gcloud config get compute/region)
+    REGION=$(curl -H "Metadata-Flavor: Google" \
+      "http://metadata.google.internal/computeMetadata/v1/instance/zone" |
+      awk -F'/' '{print $NF}' | 
+      sed 's/-[a-z]$//')
     # This needs a config file to identify the project files to upload and the
     # Dockerfile to run.
     gcloud builds submit --timeout=15m --config runscripts/container/cloud_build.json \

--- a/runscripts/container/build-wcm.sh
+++ b/runscripts/container/build-wcm.sh
@@ -26,7 +26,7 @@ print_usage() {
 while getopts 'r:w:l' flag; do
   case "${flag}" in
     r) RUNTIME_IMAGE="${OPTARG}" ;;
-    w) WCN_IMAGE="${OPTARG}" ;;
+    w) WCM_IMAGE="${OPTARG}" ;;
     l) RUN_LOCAL="${OPTARG}" ;;
     *) print_usage
        exit 1 ;;
@@ -56,8 +56,8 @@ else
     # Dockerfile to run.
     gcloud builds submit --timeout=15m --config runscripts/container/cloud_build.json \
         --substitutions="_REGION=${REGION},_WCM_RUNTIME=${RUNTIME_IMAGE},\
-        _WCM_CODE=${WCM_IMAGE},_GIT_HASH=${GIT_HASH},_GIT_BRANCH=${GIT_BRANCH},\
-        _TIMESTAMP=${TIMESTAMP}"
+_WCM_CODE=${WCM_IMAGE},_GIT_HASH=${GIT_HASH},_GIT_BRANCH=${GIT_BRANCH},\
+_TIMESTAMP=${TIMESTAMP}"
 fi
 
 rm source-info/git_diff.txt

--- a/runscripts/container/cloud_build.json
+++ b/runscripts/container/cloud_build.json
@@ -9,7 +9,7 @@
             "--build-arg", "git_branch=${_GIT_BRANCH}",
             "--build-arg", "timestamp=${_TIMESTAMP}",
             "-t", "${_REGION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_WCM_CODE}",
-            "-f", "cloud/docker/wholecell/Dockerfile",
+            "-f", "runscripts/container/wholecell/Dockerfile",
             "."
         ]
     }

--- a/runscripts/container/runtime/Dockerfile
+++ b/runscripts/container/runtime/Dockerfile
@@ -1,7 +1,7 @@
 # Container image #1: wcm-runtime.
 # This Dockerfile builds the runtime environment for the whole cell model.
 #
-# To build this image locally from the vivarium-ecoli/ project root directory:
+# To build this image locally from the vEcoli/ project root directory:
 #
 #     > docker build -f cloud/docker/runtime/Dockerfile -t ${USER}-wcm-runtime .
 #

--- a/runscripts/container/runtime/Dockerfile
+++ b/runscripts/container/runtime/Dockerfile
@@ -33,8 +33,8 @@ ENV OPENBLAS_NUM_THREADS=1
 COPY requirements.txt /
 RUN (b1="" \
     && echo "Installing pips with '$b1'" \
-    && pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir numpy==1.26.3 $b1 \
+    && pip install --no-cache-dir --upgrade pip setuptools==73.0.1 wheel \
+    && pip install --no-cache-dir numpy==1.26.4 $b1 \
     && pip install --no-cache-dir -r requirements.txt $b1 \
     && umask 000 && mkdir -p /.aesara)
 

--- a/runscripts/container/wholecell/Dockerfile
+++ b/runscripts/container/wholecell/Dockerfile
@@ -1,8 +1,8 @@
 # Container image #2: wcm-code.
-# This Dockerfile builds a container image with the vivarium-ecoli whole cell model
+# This Dockerfile builds a container image with the vEcoli whole cell model
 # code, layered on the wcm-runtime container image.
 #
-# To build this image locally from the vivarium-ecoli/ project root directory:
+# To build this image locally from the vEcoli/ project root directory:
 #
 #     > docker build -f cloud/docker/wholecell/Dockerfile -t ${USER}-wcm-code --build-arg from=${USER}-wcm-runtime .
 #
@@ -44,19 +44,19 @@ ENV IMAGE_GIT_HASH="$git_hash" \
 
 LABEL application="Whole Cell Model of Escherichia coli" \
     email="allencentercovertlab@gmail.com" \
-    license="https://github.com/CovertLab/vivarium-ecoli/blob/master/LICENSE" \
+    license="https://github.com/CovertLab/vEcoli/blob/master/LICENSE" \
     organization="Covert Lab at Stanford" \
     website="https://www.covert.stanford.edu/"
 
-COPY . /vivarium-ecoli
-WORKDIR /vivarium-ecoli
+COPY . /vEcoli
+WORKDIR /vEcoli
 
 RUN make clean compile
-ENV PYTHONPATH=/vivarium-ecoli
+ENV PYTHONPATH=/vEcoli
 
 # Since this build runs as root, set permissions so running the container as
 # another user will work: Aesara needs to write into the data dir it uses when
-# running as a user with no home dir, and Parca writes into /vivarium-ecoli/cache/.
-RUN (umask 000 && mkdir -p /.aesara /vivarium-ecoli/cache)
+# running as a user with no home dir, and Parca writes into /vEcoli/cache/.
+RUN (umask 000 && mkdir -p /.aesara /vEcoli/cache)
 
 CMD ["/bin/bash"]

--- a/runscripts/nextflow/analysis.nf
+++ b/runscripts/nextflow/analysis.nf
@@ -1,5 +1,5 @@
 process analysisSingle {
-    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}"
+    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}", mode: "move"
 
     tag "variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}"
 
@@ -47,7 +47,7 @@ process analysisSingle {
 }
 
 process analysisMultiDaughter {
-    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}"
+    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}", mode: "move"
 
     tag "variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}"
 
@@ -93,7 +93,7 @@ process analysisMultiDaughter {
 }
 
 process analysisMultiGeneration {
-    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}/lineage_seed=${lineage_seed}"
+    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}/lineage_seed=${lineage_seed}", mode: "move"
 
     tag "variant=${variant}/lineage_seed=${lineage_seed}"
 
@@ -137,7 +137,7 @@ process analysisMultiGeneration {
 }
 
 process analysisMultiSeed {
-    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}"
+    publishDir "${params.publishDir}/${params.experimentId}/analyses/variant=${variant}", mode: "move"
 
     tag "variant=${variant}"
 
@@ -179,7 +179,7 @@ process analysisMultiSeed {
 }
 
 process analysisMultiVariant {
-    publishDir "${params.publishDir}/${params.experimentId}/analyses"
+    publishDir "${params.publishDir}/${params.experimentId}/analyses", mode: "move"
 
     input:
     path config

--- a/runscripts/nextflow/colony.nf
+++ b/runscripts/nextflow/colony.nf
@@ -9,7 +9,7 @@ process colony {
 
     script:
     """
-    python /vivarium-ecoli/ecoli/experiments/ecoli_engine_process.py --config $config --sim_data_path $sim_data --initial_state_file $initial_state
+    python /vEcoli/ecoli/experiments/ecoli_engine_process.py --config $config --sim_data_path $sim_data --initial_state_file $initial_state
     STATUS=$?
     """
 

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -29,7 +29,14 @@ profiles {
         params.publishDir = "PUBLISH_DIR"
         process.maxRetries = 1
         // Check Google Cloud latest spot pricing / performance
-        process.machineType = 't2d-standard-1'
+        process.machineType = { 
+            def cpus = task.cpus
+            def powerOf2 = 1
+            while (powerOf2 < cpus && powerOf2 < 64) {
+                powerOf2 *= 2
+            }
+            return "t2d-standard-${powerOf2}"
+        }
         workflow.failOnIgnore = true
     }
     sherlock {

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -21,6 +21,8 @@ profiles {
             // Codes: 137 (out-of-memory)
             ((task.exitStatus == 137)
             && (task.attempt <= process.maxRetries)) ? 'retry' : 'ignore' }
+        // Symlinks break when files go through process chains (nextflow#4845)
+        process.stageInMode = 'copy'
         google.project = 'allen-discovery-center-mcovert'
         google.location = 'us-west1'
         google.batch.spot = true

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -25,7 +25,7 @@ profiles {
         google.location = 'us-west1'
         google.batch.spot = true
         docker.enabled = true
-        params.projectRoot = '/vivarium-ecoli'
+        params.projectRoot = '/vEcoli'
         params.publishDir = "PUBLISH_DIR"
         process.maxRetries = 1
         // Check Google Cloud latest spot pricing / performance

--- a/runscripts/nextflow/sim.nf
+++ b/runscripts/nextflow/sim.nf
@@ -1,5 +1,5 @@
 process simGen0 {
-    publishDir path: "${params.publishDir}/${params.experimentId}/daughter_states/variant=${sim_data.getBaseName()}/seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}",  pattern: "*.json"
+    publishDir path: "${params.publishDir}/${params.experimentId}/daughter_states/variant=${sim_data.getBaseName()}/seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}",  pattern: "*.json", mode: "copy"
 
     tag "variant=${sim_data.getBaseName()}/seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}"
 
@@ -52,7 +52,7 @@ process simGen0 {
 }
 
 process sim {
-    publishDir path: "${params.publishDir}/${params.experimentId}/daughter_states/variant=${sim_data.getBaseName()}/seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}",  pattern: "*.json"
+    publishDir path: "${params.publishDir}/${params.experimentId}/daughter_states/variant=${sim_data.getBaseName()}/seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}",  pattern: "*.json", mode: "copy"
 
     tag "variant=${sim_data.getBaseName()}/seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}"
 

--- a/runscripts/nextflow/template.nf
+++ b/runscripts/nextflow/template.nf
@@ -1,6 +1,6 @@
 process runParca {
     // Run ParCa using parca_options from config JSON
-    publishDir "${params.publishDir}/${params.experimentId}/parca"
+    publishDir "${params.publishDir}/${params.experimentId}/parca", mode: "copy"
 
     cpus PARCA_CPUS
 
@@ -26,21 +26,21 @@ process runParca {
 }
 
 process analysisParca {
-    publishDir "${params.publishDir}/${params.experimentId}/parca/analysis"
+    publishDir "${params.publishDir}/${params.experimentId}/parca/analysis", mode: "move"
 
     input:
     path config
     path kb
 
     output:
-    path '*'
+    path 'plots/*'
 
     script:
     """
     PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \
         --sim_data_path=$kb/simData.cPickle \
         --validation_data_path=$kb/validationData.cPickle \
-        -o \$(pwd) \
+        -o \$(pwd)/plots \
         -t parca
     """
 
@@ -53,7 +53,7 @@ process analysisParca {
 
 process createVariants {
     // Parse variants in config JSON to generate variants
-    publishDir "${params.publishDir}/${params.experimentId}/variant_sim_data"
+    publishDir "${params.publishDir}/${params.experimentId}/variant_sim_data", mode: "copy"
 
     input:
     path config

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -288,7 +288,7 @@ def main():
         config["suffix_time"] = False
 
     # Resolve output directory
-    if "out_uri" not in config["emitter"]:
+    if "out_uri" not in config["emitter_arg"]:
         out_uri = os.path.abspath(config["emitter_arg"]["out_dir"])
         config["emitter_arg"]["out_dir"] = out_uri
     else:
@@ -331,8 +331,8 @@ def main():
             if runtime_image_name is None:
                 raise RuntimeError("Must supply name for runtime image.")
             build_runtime_image(runtime_image_name)
+        wcm_image_name = cloud_config.get("wcm_image_name", None)
         if cloud_config.get("build_wcm_image", False):
-            wcm_image_name = cloud_config.get("wcm_image_name", None)
             if wcm_image_name is None:
                 raise RuntimeError("Must supply name for WCM image.")
             build_wcm_image(wcm_image_name, runtime_image_name)

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -392,7 +392,7 @@ def main():
                 workdir,
                 "-resume" if args.resume else "",
             ],
-            check=True
+            check=True,
         )
     elif nf_profile == "sherlock":
         batch_script = os.path.join(local_outdir, "nextflow_job.sh")

--- a/wholecell/tests/utils/test_mc_complexation.py
+++ b/wholecell/tests/utils/test_mc_complexation.py
@@ -2,10 +2,15 @@
 Test polymerize_new.py
 """
 
-from wholecell.utils.mc_complexation import (
-    mccBuildMatrices,
-    mccFormComplexesWithPrebuiltMatrices,
-)
+try:
+    from wholecell.utils.mc_complexation import (
+        mccBuildMatrices,
+        mccFormComplexesWithPrebuiltMatrices,
+    )
+except ImportError as exc:
+    raise RuntimeError(
+        "Failed to import Cython module. Try running 'make clean compile'."
+    ) from exc
 
 import numpy as np
 import numpy.testing as npt

--- a/wholecell/utils/polymerize.py
+++ b/wholecell/utils/polymerize.py
@@ -12,8 +12,13 @@ TODO:
 
 import numpy as np
 
-from ._build_sequences import buildSequences, computeMassIncrease
-from ._fastsums import sum_monomers, sum_monomers_reference_implementation
+try:
+    from ._build_sequences import buildSequences, computeMassIncrease
+    from ._fastsums import sum_monomers, sum_monomers_reference_implementation
+except ImportError as exc:
+    raise RuntimeError(
+        "Failed to import Cython module. Try running 'make clean compile'."
+    ) from exc
 
 # Reexport these Cython functions. Declaring them avoids
 # "unused import statement" warnings.


### PR DESCRIPTION
- If Cython modules are missing, raise error message telling user to run `make clean compile`
- Document that two config JSONs are required to run ParCa and simulation manually (outside a workflow). This forces the user to be explicit about the `sim_data_path` used by the simulation, reducing the chance of using the wrong simulation data.
- Tell Nextflow to move all analysis output to [final output directory structure](https://covertlab.github.io/vEcoli/workflows.html#id9). Also, create copies of ParCa output and simulation data variants in their final output folders. This allows users to safely delete the entire `nextflow_workdirs` directory without losing any of the key simulation outputs.
- Add minimal documentation for troubleshooting Nextflow workflows
- Fix bug with unified Parquet schema being written to wrong path
- Fix bugs running on Google Cloud