### PR TITLE
Use personal nextflow installation instead of module

### DIFF
--- a/runscripts/jenkins/setup-environment.sh
+++ b/runscripts/jenkins/setup-environment.sh
@@ -1,7 +1,7 @@
 set -e
 
 export PYTHONPATH=$PWD
-module load wcEcoli/python3 java/18.0.2 biology nextflow
+module load wcEcoli/python3 java/18.0.2
 
 export PATH="${GROUP_HOME}/pyenv/bin:${PATH}"
 eval "$(pyenv init -)"


### PR DESCRIPTION
I added a copy of the nextflow binary to `$GROUP_HOME/pyenv/bin`. This allows us to manually update nextflow for bug fixes and new features immediately instead of waiting for Sherlock maintainers to update the nextflow module.