### PR TITLE
Use nextflow to distribute Jenkins CI over Sherlock nodes

### DIFF
--- a/runscripts/jenkins/configs/ecoli-anaerobic.json
+++ b/runscripts/jenkins/configs/ecoli-anaerobic.json
@@ -19,6 +19,7 @@
         "single": {"mass_fraction_summary": {}}
     },
     "variants": {
-        "condition": {"condition": "no_oxygen"}
-    }
+        "condition": {"condition": {"value": ["no_oxygen"]}}
+    },
+    "sherlock": true
 }

--- a/runscripts/jenkins/configs/ecoli-glucose-minimal.json
+++ b/runscripts/jenkins/configs/ecoli-glucose-minimal.json
@@ -9,5 +9,6 @@
     },
     "analysis_options": {
         "single": {"mass_fraction_summary": {}}
-    }
+    },
+    "sherlock": true
 }

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -33,5 +33,6 @@
             },
             "op": "zip"
         }
-    }
+    },
+    "sherlock": true
 }

--- a/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
+++ b/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
@@ -16,5 +16,6 @@
     },
     "analysis_options": {
         "single": {"mass_fraction_summary": {}}
-    }
+    },
+    "sherlock": true
 }

--- a/runscripts/jenkins/configs/ecoli-no-operons.json
+++ b/runscripts/jenkins/configs/ecoli-no-operons.json
@@ -12,5 +12,6 @@
     },
     "analysis_options": {
         "single": {"mass_fraction_summary": {}}
-    }
+    },
+    "sherlock": true
 }

--- a/runscripts/jenkins/configs/ecoli-superhelical-density.json
+++ b/runscripts/jenkins/configs/ecoli-superhelical-density.json
@@ -10,5 +10,6 @@
     },
     "analysis_options": {
         "single": {"mass_fraction_summary": {}}
-    }
+    },
+    "sherlock": true
 }

--- a/runscripts/jenkins/configs/ecoli-with-aa.json
+++ b/runscripts/jenkins/configs/ecoli-with-aa.json
@@ -11,6 +11,7 @@
         "single": {"mass_fraction_summary": {}}
     },
     "variants": {
-        "condition": {"condition": "with_aa"}
-    }
+        "condition": {"condition": {"value": ["with_aa"]}}
+    },
+    "sherlock": true
 }


### PR DESCRIPTION
This allows us to test that the workflow pipeline (`runscripts/workflow.py`) works properly on Sherlock and means we can keep the resource requirements of the long-running Jenkins job to a minimum. One core should be enough to `git pull` the latest changes, set up the environment, and launch the Nextflow orchestrator which will submit ParCa/sim/analysis jobs to the cluster.