### PR TITLE
Filename-friendly time suffix

### DIFF
--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -829,7 +829,7 @@ class EcoliSim:
                 self.experiment_id_base = self.experiment_id
             if self.suffix_time:
                 self.experiment_id = datetime.now().strftime(
-                    f"{self.experiment_id_base}_%d-%m-%Y_%H-%M-%S"
+                    f"{self.experiment_id_base}_%Y%m%d-%H%M%S"
                 )
             # Special characters can break Hive partitioning so quote them
             self.experiment_id = parse.quote_plus(self.experiment_id)

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -283,7 +283,7 @@ def main():
     if experiment_id is None:
         raise RuntimeError("No experiment ID was provided.")
     if config["suffix_time"]:
-        current_time = datetime.now().strftime("%d-%m-%Y %H:%M:%S")
+        current_time = datetime.now().strftime("%Y%m%d-%H%M%S")
         experiment_id = experiment_id + "_" + current_time
         config["suffix_time"] = False
 


### PR DESCRIPTION
Better automatic date/time experiment ID suffix that should be more friendly for filenames (no special characters/spaces).