### PR TITLE
Do not allow special characters in experiment ID

### DIFF
--- a/doc/experiments.rst
+++ b/doc/experiments.rst
@@ -91,12 +91,11 @@ documented in :ref:`/workflows.rst`.
         # chains if possible.
         "inherit_from": [],
         # String that uniquely identifies simulation (or workflow if passed
-        # as input to runscripts/workflow.py). Avoid special characters as we
-        # quote experiment IDs using urlparse.parse.quote_plus, which may make
-        # experiment IDs with special characters hard to deciphe later.
+        # as input to runscripts/workflow.py). Special characters and spaces
+        # are not allowed (hyphens are OK).
         "experiment_id": "experiment_id_one"
         # Whether to append date and time to experiment ID in the following format
-        # experiment_id_%d-%m-%Y_%H-%M-%S.
+        # experiment_id_%Y%m%d-%H%M%S.
         "suffix_time": true,
         # Optional string description of simulation
         "description": "",

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -831,8 +831,13 @@ class EcoliSim:
                 self.experiment_id = datetime.now().strftime(
                     f"{self.experiment_id_base}_%Y%m%d-%H%M%S"
                 )
-            # Special characters can break Hive partitioning so quote them
-            self.experiment_id = parse.quote_plus(self.experiment_id)
+            # Special characters can break Hive partitioning so do not allow them
+            if self.experiment_id != parse.quote_plus(self.experiment_id):
+                raise TypeError(
+                    "Experiment ID cannot contain special characters"
+                    f"that change the string when URL quoted: {self.experiment_id}"
+                    f" != {parse.quote_plus(self.experiment_id)}"
+                )
             experiment_config["experiment_id"] = self.experiment_id
         experiment_config["profile"] = self.profile
 

--- a/ecoli/processes/polypeptide_elongation.py
+++ b/ecoli/processes/polypeptide_elongation.py
@@ -1139,10 +1139,12 @@ class SteadyStateElongationModel(TranslationSupplyElongationModel):
             request_ppgpp_metabolites = -delta_metabolites
             ppgpp_request = counts(states["bulk"], self.process.ppgpp_idx)
             bulk_request.append((self.process.ppgpp_idx, ppgpp_request))
-            bulk_request.append((
-                self.process.ppgpp_rxn_metabolites_idx,
-                request_ppgpp_metabolites.astype(int),
-            ))
+            bulk_request.append(
+                (
+                    self.process.ppgpp_rxn_metabolites_idx,
+                    request_ppgpp_metabolites.astype(int),
+                )
+            )
 
         return (
             fraction_charged,

--- a/runscripts/jenkins/configs/ecoli-anaerobic.json
+++ b/runscripts/jenkins/configs/ecoli-anaerobic.json
@@ -1,5 +1,5 @@
 {
-    "experiment_id": "Daily anaerobic",
+    "experiment_id": "daily-anaerobic",
     "single_daughters": true,
     "generations": 8,
     "fail_at_total_time": true,

--- a/runscripts/jenkins/configs/ecoli-glucose-minimal.json
+++ b/runscripts/jenkins/configs/ecoli-glucose-minimal.json
@@ -1,5 +1,5 @@
 {
-    "experiment_id": "Daily build",
+    "experiment_id": "daily-build",
     "single_daughters": true,
     "generations": 16,
     "fail_at_total_time": true,

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -1,5 +1,5 @@
 {
-    "experiment_id": "Daily new gene GFP",
+    "experiment_id": "daily-new-gene-gfp",
     "single_daughters": true,
     "generations": 4,
     "fail_at_total_time": true,

--- a/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
+++ b/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
@@ -1,5 +1,5 @@
 {
-    "experiment_id": "Daily no growth rate control",
+    "experiment_id": "daily-no-growth-rate-control",
     "single_daughters": true,
     "generations": 4,
     "fail_at_total_time": true,

--- a/runscripts/jenkins/configs/ecoli-no-operons.json
+++ b/runscripts/jenkins/configs/ecoli-no-operons.json
@@ -1,5 +1,5 @@
 {
-    "experiment_id": "Daily no operons",
+    "experiment_id": "daily-no-operons",
     "single_daughters": true,
     "generations": 4,
     "fail_at_total_time": true,

--- a/runscripts/jenkins/configs/ecoli-superhelical-density.json
+++ b/runscripts/jenkins/configs/ecoli-superhelical-density.json
@@ -1,5 +1,5 @@
 {
-    "experiment_id": "Daily superhelical density",
+    "experiment_id": "daily-superhelical-density",
     "single_daughters": true,
     "generations": 4,
     "fail_at_total_time": true,

--- a/runscripts/jenkins/configs/ecoli-with-aa.json
+++ b/runscripts/jenkins/configs/ecoli-with-aa.json
@@ -1,5 +1,5 @@
 {
-    "experiment_id": "Daily with AA",
+    "experiment_id": "daily-with-aa",
     "single_daughters": true,
     "generations": 8,
     "fail_at_total_time": true,


### PR DESCRIPTION
Special characters and spaces in the experiment ID completely messes up the directory structure. Better just to disallow them.