### PR TITLE
Tweak SLURM executor options to try to minimize downtime

### DIFF
--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -87,22 +87,19 @@ profiles {
         params.publishDir = "PUBLISH_DIR"
         // Avoid getting queue status too frequently (can cause job status mixups)
         executor.queueStatInterval = '2 min'
-        // Check for terminated jobs and submit new ones less frequently
-        // than we check queue status (ensure correct and latest status) 
-        executor.pollInterval = '5 min'
+        // Check for terminated jobs and submit new ones fairly frequently
+        // to minimize downtime between dependent jobs
+        executor.pollInterval = '30 sec'
         // Retry all jobs that fail to submit (different from fail during runtime)
         executor.submit.retry.reason = '.*'
         // Retry failed submissions with delay longer than the time to
-        // get latest correct queue status (avoid job status mixups)
-        executor.retry.delay = '5 min'
-        executor.retry.maxDelay = '10 min'
+        // get latest queue status (avoid job status mixups)
+        executor.retry.delay = '3 min'
+        executor.retry.maxDelay = '5 min'
         // Throttle submission rate to avoid overwhelming scheduler
         executor.submitRateLimit = '20/min'
         // Give NFS time to update and sync before raising errors
-        executor.exitReadTimeout = '15 min'
-        // Write out job status to log file less frequently
-        // than we check queue status (log correct and latest status)
-        executor.dumpInterval = '6 min'
+        executor.exitReadTimeout = '10 min'
         workflow.failOnIgnore = true
     }
     standard {


### PR DESCRIPTION
The conservative SLURM executor options that I set to avoid sporadic job submission errors in #230 lead to large periods of downtime where a job has finished but Nextflow has not recognized it as such. This PR attempts to tweak those options to reduce downtime while still avoiding those errors.