### PR TITLE
Sherlock optimizations

### DIFF
--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -563,9 +563,9 @@ be absolute because Nextflow does not resolve environment variables like
 ``$SCRATCH`` in paths.
 
 .. warning::
-    Running the workflow on Sherlock sets a 2 hour limit on each job in the
+    Running the workflow on Sherlock sets a 1 hour limit on each job in the
     workflow, including analyses. Analysis scripts that take more than
-    2 hours to run should be excluded from workflow configurations and manually
+    1 hours to run should be excluded from workflow configurations and manually
     run using :py:mod:`runscripts.analysis` afterwards.
 
 .. _sherlock-interactive:
@@ -665,7 +665,7 @@ is a list workflow behaviors enabled in our model to handle unexpected errors.
   are automatically retried up to a maximum of 3 tries. For the resource
   limit error code (140), Nextflow will automatically request more RAM
   and a higher runtime limit with each attempt: ``4 * {attempt num}``
-  GB of memory and ``2 * {attempt num}`` hours of runtime. See the
+  GB of memory and ``1 * {attempt num}`` hours of runtime. See the
   ``sherlock`` profile in ``runscripts/nextflow/config.template``.
 - Additionally, some jobs may fail on Sherlock due to issues submitting
   them to the SLURM scheduler. Nextflow was configured to limit the rate

--- a/ecoli/analysis/multigeneration/new_gene_counts.py
+++ b/ecoli/analysis/multigeneration/new_gene_counts.py
@@ -94,7 +94,7 @@ def plot(
     )
 
     # mRNA counts
-    mrna_plot = new_gene_data.hvplot.line( # type: ignore[attr-defined]
+    mrna_plot = new_gene_data.hvplot.line(  # type: ignore[attr-defined]
         x="Time (min)",
         y=new_gene_mRNA_ids,
         ylabel="mRNA Counts",
@@ -102,7 +102,7 @@ def plot(
     )
 
     # Protein counts
-    protein_plot = new_gene_data.hvplot.line( # type: ignore[attr-defined]
+    protein_plot = new_gene_data.hvplot.line(  # type: ignore[attr-defined]
         x="Time (min)",
         y=new_gene_monomer_ids,
         ylabel="Protein Counts",

--- a/ecoli/analysis/single/mass_fraction_summary.py
+++ b/ecoli/analysis/single/mass_fraction_summary.py
@@ -63,7 +63,7 @@ def plot(
         },
     }
     mass_fold_change = pl.DataFrame(new_columns)
-    plot_namespace = mass_fold_change.hvplot # type: ignore[attr-defined]
+    plot_namespace = mass_fold_change.hvplot  # type: ignore[attr-defined]
     # hvplot.output(backend='matplotlib')
     plotted_data = plot_namespace.line(
         x="Time (min)",

--- a/runscripts/jenkins/configs/ecoli-anaerobic.json
+++ b/runscripts/jenkins/configs/ecoli-anaerobic.json
@@ -29,8 +29,5 @@
         "runtime_image_name": "runtime-image",
         "build_runtime_image": true,
         "jenkins": true
-    },
-    "parca_options": {
-        "cpus": 4
     }
 }

--- a/runscripts/jenkins/configs/ecoli-glucose-minimal.json
+++ b/runscripts/jenkins/configs/ecoli-glucose-minimal.json
@@ -15,8 +15,5 @@
         "runtime_image_name": "runtime-image",
         "build_runtime_image": true,
         "jenkins": true
-    },
-    "parca_options": {
-        "cpus": 4
     }
 }

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -9,8 +9,7 @@
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "parca_options": {
-        "new_genes": "gfp",
-        "cpus": 4
+        "new_genes": "gfp"
     },
     "analysis_options": {
         "single": {"mass_fraction_summary": {}}

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -38,7 +38,6 @@
     },
     "sherlock": {
         "runtime_image_name": "runtime-image",
-        "build_runtime_image": true,
         "jenkins": true
     }
 }

--- a/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
+++ b/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
@@ -22,8 +22,5 @@
         "runtime_image_name": "runtime-image",
         "build_runtime_image": true,
         "jenkins": true
-    },
-    "parca_options": {
-        "cpus": 4
     }
 }

--- a/runscripts/jenkins/configs/ecoli-no-operons.json
+++ b/runscripts/jenkins/configs/ecoli-no-operons.json
@@ -9,8 +9,7 @@
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "parca_options": {
-        "operons": false,
-        "cpus": 4
+        "operons": false
     },
     "analysis_options": {
         "single": {"mass_fraction_summary": {}}

--- a/runscripts/jenkins/configs/ecoli-no-operons.json
+++ b/runscripts/jenkins/configs/ecoli-no-operons.json
@@ -16,7 +16,6 @@
     },
     "sherlock": {
         "runtime_image_name": "runtime-image",
-        "build_runtime_image": true,
         "jenkins": true
     }
 }

--- a/runscripts/jenkins/configs/ecoli-superhelical-density.json
+++ b/runscripts/jenkins/configs/ecoli-superhelical-density.json
@@ -16,8 +16,5 @@
         "runtime_image_name": "runtime-image",
         "build_runtime_image": true,
         "jenkins": true
-    },
-    "parca_options": {
-        "cpus": 4
     }
 }

--- a/runscripts/jenkins/configs/ecoli-superhelical-density.json
+++ b/runscripts/jenkins/configs/ecoli-superhelical-density.json
@@ -14,7 +14,6 @@
     },
     "sherlock": {
         "runtime_image_name": "runtime-image",
-        "build_runtime_image": true,
         "jenkins": true
     }
 }

--- a/runscripts/jenkins/configs/ecoli-with-aa.json
+++ b/runscripts/jenkins/configs/ecoli-with-aa.json
@@ -19,8 +19,5 @@
         "runtime_image_name": "runtime-image",
         "build_runtime_image": true,
         "jenkins": true
-    },
-    "parca_options": {
-        "cpus": 4
     }
 }

--- a/runscripts/nextflow/analysis.nf
+++ b/runscripts/nextflow/analysis.nf
@@ -3,6 +3,8 @@ process analysisSingle {
 
     tag "variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}/agent_id=${agent_id}"
 
+    label "short"
+
     input:
     path config
     path kb
@@ -51,6 +53,8 @@ process analysisMultiDaughter {
 
     tag "variant=${variant}/lineage_seed=${lineage_seed}/generation=${generation}"
 
+    label "short"
+
     input:
     path config
     path kb
@@ -97,6 +101,8 @@ process analysisMultiGeneration {
 
     tag "variant=${variant}/lineage_seed=${lineage_seed}"
 
+    label "short"
+
     input:
     path config
     path kb
@@ -141,6 +147,8 @@ process analysisMultiSeed {
 
     tag "variant=${variant}"
 
+    label "short"
+
     input:
     path config
     path kb
@@ -180,6 +188,8 @@ process analysisMultiSeed {
 
 process analysisMultiVariant {
     publishDir "${params.publishDir}/${params.experimentId}/analyses", mode: "move"
+
+    label "short"
 
     input:
     path config

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -2,6 +2,9 @@
 params {
     experimentId = 'EXPERIMENT_ID'
     config = 'CONFIG_FILE'
+    parca_cpus = PARCA_CPUS
+    publishDir = 'PUBLISH_DIR'
+    container_image = 'IMAGE_NAME'
 }
 
 trace {
@@ -16,11 +19,14 @@ profiles {
         // Using single core is slightly slower but much cheaper
         process.cpus = 1
         process.executor = 'google-batch'
-        process.container = 'IMAGE_NAME'
+        process.container = params.container_image
         // Necessary otherwise symlinks to other files in bucket can break
         process.containerOptions = '--volume /mnt/disks/BUCKET:/mnt/disks/BUCKET'
-        process.withLabel: short {
-            executor = 'local'
+        process {
+            withLabel: parca {
+                cpus = params.parca_cpus
+                memory = params.parca_cpus * 2.GB
+            }
         }
         process.errorStrategy = {
             // Codes: 137 (out-of-memory), 50001 - 50006 (Google Batch task fail:
@@ -48,7 +54,6 @@ profiles {
         google.batch.subnetwork = "regions/${google.location}/subnetworks/default"
         docker.enabled = true
         params.projectRoot = '/vEcoli'
-        params.publishDir = "PUBLISH_DIR"
         process.maxRetries = 1
         // Check Google Cloud latest spot pricing / performance
         process.machineType = { 
@@ -80,8 +85,21 @@ profiles {
         process.cpus = 1
         process.executor = 'slurm'
         process.queue = 'mcovert,owners'
-        process.container = 'IMAGE_NAME'
+        process.container = params.container_image
         apptainer.enabled = true
+        process {
+            // Run analyses, create variants, and run ParCa locally with
+            // the job used to launch workflow to avoid long queue times
+            withLabel: short {
+                executor = 'local'
+            },
+            // ParCa 4 CPUs in ~15 min, 1 CPU in ~30 min, not too bad
+            withLabel: parca {
+                executor = 'local'
+                cpus = 1
+                memory = 2.GB
+            }
+        }
         process.time = {
             if ( task.exitStatus == 140 ) {
                 1.h * task.attempt
@@ -91,7 +109,6 @@ profiles {
         }
         process.maxRetries = 3
         params.projectRoot = "${launchDir}"
-        params.publishDir = "PUBLISH_DIR"
         // Avoid getting queue status too frequently (can cause job status mixups)
         executor.queueStatInterval = '2 min'
         // Check for terminated jobs and submit new ones fairly frequently
@@ -112,8 +129,13 @@ profiles {
     standard {
         process.executor = 'local'
         params.projectRoot = "${launchDir}"
-        params.publishDir = "PUBLISH_DIR"
         workflow.failOnIgnore = true
         process.errorStrategy = 'ignore'
+        process {
+            withLabel: parca {
+                cpus = params.parca_cpus
+                memory = params.parca_cpus * 2.GB
+            }
+        }
     }
 }

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -77,7 +77,7 @@ profiles {
         // queue times and is less damaging to future job priority
         process.cpus = 1
         process.executor = 'slurm'
-        process.queue = 'owners'
+        process.queue = 'mcovert,owners'
         process.container = 'IMAGE_NAME'
         apptainer.enabled = true
         process.time = {

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -17,6 +17,8 @@ profiles {
         process.cpus = 1
         process.executor = 'google-batch'
         process.container = 'IMAGE_NAME'
+        // Necessary otherwise symlinks to other files in bucket can break
+        process.containerOptions = '--volume /mnt/disks/BUCKET:/mnt/disks/BUCKET'
         process.withLabel: short {
             executor = 'local'
         } 

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -21,7 +21,7 @@ profiles {
         process.containerOptions = '--volume /mnt/disks/BUCKET:/mnt/disks/BUCKET'
         process.withLabel: short {
             executor = 'local'
-        } 
+        }
         process.errorStrategy = {
             // Codes: 137 (out-of-memory), 50001 - 50006 (Google Batch task fail:
             // https://cloud.google.com/batch/docs/troubleshooting#reserved-exit-codes)

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -17,6 +17,9 @@ profiles {
         process.cpus = 1
         process.executor = 'google-batch'
         process.container = 'IMAGE_NAME'
+        process.withLabel: short {
+            executor = 'local'
+        } 
         process.errorStrategy = {
             // Codes: 137 (out-of-memory), 50001 - 50006 (Google Batch task fail:
             // https://cloud.google.com/batch/docs/troubleshooting#reserved-exit-codes)

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -79,9 +79,9 @@ profiles {
         apptainer.enabled = true
         process.time = {
             if ( task.exitStatus == 140 ) {
-                2.h * task.attempt
+                1.h * task.attempt
             } else {
-                2.h
+                1.h
             }
         }
         process.maxRetries = 3

--- a/runscripts/nextflow/template.nf
+++ b/runscripts/nextflow/template.nf
@@ -2,9 +2,7 @@ process runParca {
     // Run ParCa using parca_options from config JSON
     publishDir "${params.publishDir}/${params.experimentId}/parca", mode: "copy"
 
-    memory { task.cpus * 2.GB }
-
-    cpus PARCA_CPUS
+    label "parca"
 
     input:
     path config

--- a/runscripts/nextflow/template.nf
+++ b/runscripts/nextflow/template.nf
@@ -2,6 +2,8 @@ process runParca {
     // Run ParCa using parca_options from config JSON
     publishDir "${params.publishDir}/${params.experimentId}/parca", mode: "copy"
 
+    memory { task.cpus * 2.GB }
+
     cpus PARCA_CPUS
 
     input:

--- a/runscripts/nextflow/template.nf
+++ b/runscripts/nextflow/template.nf
@@ -30,6 +30,8 @@ process runParca {
 process analysisParca {
     publishDir "${params.publishDir}/${params.experimentId}/parca/analysis", mode: "move"
 
+    label "short"
+
     input:
     path config
     path kb
@@ -56,6 +58,8 @@ process analysisParca {
 process createVariants {
     // Parse variants in config JSON to generate variants
     publishDir "${params.publishDir}/${params.experimentId}/variant_sim_data", mode: "copy"
+
+    label "short"
 
     input:
     path config

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -1,13 +1,11 @@
 import argparse
 import json
 import os
-import time
 import shutil
 import subprocess
 import warnings
 from datetime import datetime
 from urllib import parse
-from typing import Optional
 
 from pyarrow import fs
 

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -346,11 +346,13 @@ def main():
             f" != {parse.quote_plus(experiment_id)}"
         )
     # Resolve output directory
+    out_bucket = ""
     if "out_uri" not in config["emitter_arg"]:
         out_uri = os.path.abspath(config["emitter_arg"]["out_dir"])
         config["emitter_arg"]["out_dir"] = out_uri
     else:
         out_uri = config["emitter_arg"]["out_uri"]
+        out_bucket = out_uri.split("://")[1].split("/")[0]
     # Resolve sim_data_path if provided
     if config["sim_data_path"] is not None:
         config["sim_data_path"] = os.path.abspath(config["sim_data_path"])
@@ -363,6 +365,7 @@ def main():
     filesystem.create_dir(outdir)
     temp_config_path = f"{local_outdir}/workflow_config.json"
     final_config_path = os.path.join(outdir, "workflow_config.json")
+    final_config_uri = os.path.join(out_uri, "workflow_config.json")
     with open(temp_config_path, "w") as f:
         json.dump(config, f)
     if not args.resume:
@@ -373,7 +376,8 @@ def main():
         nf_config = f.readlines()
     nf_config = "".join(nf_config)
     nf_config = nf_config.replace("EXPERIMENT_ID", experiment_id)
-    nf_config = nf_config.replace("CONFIG_FILE", temp_config_path)
+    nf_config = nf_config.replace("CONFIG_FILE", final_config_uri)
+    nf_config = nf_config.replace("BUCKET", out_bucket)
     nf_config = nf_config.replace(
         "PUBLISH_DIR", os.path.dirname(os.path.dirname(out_uri))
     )

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -381,6 +381,9 @@ def main():
     nf_config = nf_config.replace(
         "PUBLISH_DIR", os.path.dirname(os.path.dirname(out_uri))
     )
+    nf_config = nf_config.replace(
+        "PARCA_CPUS", str(config["parca_options"]["cpus"])
+    )
 
     # By default, assume running on local device
     nf_profile = "standard"
@@ -457,9 +460,6 @@ def main():
     nf_template = nf_template.replace("RUN_PARCA", run_parca)
     nf_template = nf_template.replace("IMPORTS", sim_imports)
     nf_template = nf_template.replace("WORKFLOW", sim_workflow)
-    nf_template = nf_template.replace(
-        "PARCA_CPUS", str(config["parca_options"]["cpus"])
-    )
     local_workflow = os.path.join(local_outdir, "main.nf")
     with open(local_workflow, "w") as f:
         f.writelines(nf_template)


### PR DESCRIPTION
When running workflows on Sherlock, the Nextflow process that orchestrates the workflow is submitted to SLURM as a long-running, 1 CPU job that stays alive for the duration of the workflow. It is responsible for submitting additional jobs to SLURM for each task in the workflow. Those tasks must wait in the SLURM queue until a node frees up. All the while, the Nextflow job remains mostly idle. This PR fills this idle CPU time by running certain short workflow tasks (build runtime image, analyses, create variants) directly on the same job as the Nextflow orchestrator, simultaneously avoiding the wait that currently comes with submitting those tasks to the SLURM queue (~15 minute average). I found that after including queue wait time, the ParCa takes about the same time to finish whether it is submitted to the queue as a 4 CPU job or run locally on the 1 CPU Nextflow job. Therefore, I made that run locally as well.

Other changes:
- Fixed a previously overlooked symlinking issue
- Fixed ``chromosome_segment`` unique molecule that is required for ``superhelical_density`` sims