### PR TITLE
Minor quality of life improvements

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# Greatly improves performance and reproducibility
-OMP_NUM_THREADS=1

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -22,22 +22,22 @@ jobs:
       run: USE_CYTHON=1 uv sync --frozen
     - name: Test ParCa reproducibility
       run: |
-        uv run --env-file .env runscripts/parca.py --config ecoli/composites/ecoli_configs/run_parca.json \
+        uv run runscripts/parca.py --config ecoli/composites/ecoli_configs/run_parca.json \
             -c 3 -o out/parca_1
-        uv run --env-file .env runscripts/parca.py --config ecoli/composites/ecoli_configs/run_parca.json \
+        uv run runscripts/parca.py --config ecoli/composites/ecoli_configs/run_parca.json \
             -c 3 -o out/parca_2
-        uv run --env-file .env runscripts/debug/compare_pickles.py out/parca_1/kb out/parca_2/kb
+        uv run runscripts/debug/compare_pickles.py out/parca_1/kb out/parca_2/kb
     - name: Test simulation reproducibility
       run: |
-        uv run --env-file .env ecoli/experiments/ecoli_master_sim.py \
+        uv run ecoli/experiments/ecoli_master_sim.py \
             --generations 1 --emitter parquet --emitter_arg out_dir='out' \
             --experiment_id "parca_1" --daughter_outdir "out/parca_1" \
             --sim_data_path "out/parca_1/kb/simData.cPickle" --fail_at_total_time &
-        uv run --env-file .env ecoli/experiments/ecoli_master_sim.py \
+        uv run ecoli/experiments/ecoli_master_sim.py \
             --generations 1 --emitter parquet --emitter_arg out_dir='out' \
             --experiment_id "parca_2" --daughter_outdir "out/parca_2" \
             --sim_data_path "out/parca_2/kb/simData.cPickle" --fail_at_total_time
-        uv run --env-file .env runscripts/debug/diff_simouts.py -o "out" "parca_1*" "parca_2*"
+        uv run runscripts/debug/diff_simouts.py -o "out" "parca_1*" "parca_2*"
   Two-gens:
     runs-on: macos-latest
     steps:
@@ -57,4 +57,4 @@ jobs:
         NXF_EDGE=1 ./nextflow self-update
     - name: Two generations
       run: |
-        uv run --env-file .env runscripts/workflow.py --config ecoli/composites/ecoli_configs/two_generations.json
+        uv run runscripts/workflow.py --config ecoli/composites/ecoli_configs/two_generations.json

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Test with pytest
       run: |
-        uv run --env-file .env pytest --cov-report xml:cov.xml --cov=ecoli --cov=reconstruction --cov=wholecell --cov=runscripts --durations=0
+        uv run pytest --cov-report xml:cov.xml --cov=ecoli --cov=reconstruction --cov=wholecell --cov=runscripts --durations=0
     - name: Code Coverage Report
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
@@ -49,7 +49,7 @@ jobs:
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Mypy
       run: |
-        uv run --env-file .env mypy
+        uv run mypy
   Lint:
     runs-on: ubuntu-latest
     steps:
@@ -63,4 +63,4 @@ jobs:
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Ruff
       run: |
-        uv run --env-file .env ruff check doc ecoli migration wholecell runscripts validation reconstruction
+        uv run ruff check doc ecoli migration wholecell runscripts validation reconstruction

--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ perform static type checking.
 
 To test your installation, from the top-level of the cloned repository, invoke:
 
-    uv run --env-file .env runscripts/workflow.py --config ecoli/composites/ecoli_configs/test_installation.json
+    uv run runscripts/workflow.py --config ecoli/composites/ecoli_configs/test_installation.json
 
-> **Note:** Start all of your commands to run scripts with `uv run --env-file .env`.
-> You can create an alias by appending `alias uvrun="uv run --env-file .env"`
-> to your `~/.zshrc` or `~/.bashrc`. Then, you can start commands with `uvrun`.
+> **Note:** Start all of your commands to run scripts with `uv run`. Alternatively,
+> you can source the Python virtual environment that `uv` created with
+> `source .venv/bin/activate` and use `python` as normal, though we recommend
+> sticking to `uv run` where possible.
 
 This will run the following basic simulation workflow:
 

--- a/doc/docs.rst
+++ b/doc/docs.rst
@@ -502,7 +502,7 @@ from plain text. Here are stepwise instructions:
    .. code-block:: console
 
         $ cd doc
-        $ uv run --env-file .env make html
+        $ uv run make html
 
    Your HTML will now be in ``doc/_build/html``. To view it, open
    ``doc/_build/html/index.html`` in a web browser.

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -568,22 +568,22 @@ be absolute because Nextflow does not resolve environment variables like
 Interactive Container
 =====================
 
-To run and develop the model on Sherlock outside a workflow, run::
+To run and develop the model on Sherlock outside a workflow, you must
+have run a containerized workflow (default on Sherlock) with
+``build_runtime_image`` set to true and the most recent version of
+``uv.lock``. If you are not sure if ``uv.lock`` changed since your last
+containerized workflow (or if you have never run a containerized workflow),
+run the following to build a runtime image, picking any ``runtime_image_path``::
+  
+  runscripts/container/build-runtime.sh -r runtime_image_path -a::
+
+Once you have a runtime image, you can start an interactive container with::
 
   runscripts/container/interactive.sh -w runtime_image_path -a
 
-Replace ``runtime_image_path`` with the path of an Apptainer image built with
-the latest ``uv.lock``, which contains the version of the Python packages that
-``uv`` will install. If you are not sure if ``uv.lock``
-changed since the last time you ran a workflow with ``build_runtime_image``
-set to true (or if you have never run a workflow), run the following to build
-a runtime image, picking any ``runtime_image_path``::
-  
-  runscripts/container/build-runtime.sh -r runtime_image_path -a
-
-Inside the container, set the ``PYTHONPATH`` with ``export PYTHONPATH={}``,
-substituting in the path to your cloned ``vEcoli`` repository. You can now run
-any of the scripts in ``runscripts``.
+You can now use vEcoli as normal. Any code changes that you make in the
+cloned repository will be immediately reflected in commands run inside the
+container.
 
 If you are trying to debug a failed process, add breakpoints to any Python script
 in your cloned repository by inserting::

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -577,7 +577,7 @@ the latest ``uv.lock``, which contains the version of the Python packages that
 ``uv`` will install. If you are not sure if ``uv.lock``
 changed since the last time you ran a workflow with ``build_runtime_image``
 set to true (or if you have never run a workflow), run the following to build
-a runtime image, picking any path::
+a runtime image, picking any ``runtime_image_path``::
   
   runscripts/container/build-runtime.sh -r runtime_image_path -a
 
@@ -811,12 +811,14 @@ Add breakpoints to any Python file with the following line::
 
   import ipdb; ipdb.set_trace()
 
-Then, navigate to the working directory (see :ref:`troubleshooting`) for a
-failing process. Invoke ``uv run --env-file {} .command.run``, replacing
-the curly braces with the path to the ``.env`` file in your cloned repository.
-This should re-run the job and pause upon reaching the breakpoints you set.
-You should now be in an ipdb shell which you can use to examine variable values
-or step through the code.
+Figure out the working directory (see :ref:`troubleshooting`) for a
+failing process. Invoke ``uv run --directory {} .command.run`` from your
+cloned repository, replacing the curly braces with the path to the working
+directory. Alternatively, navigate to the working directory and invokes
+``uv run --project {} .command.run``, replacing the curly braces with the
+path to the cloned repository. This should re-run the job and pause upon
+reaching the breakpoints you set. You should now be in an ipdb shell which
+you can use to examine variable values or step through the code.
 
 After fixing the issue, you can resume the workflow (avoid re-running
 already successful jobs) by navigating back to the directory in which you

--- a/ecoli/__init__.py
+++ b/ecoli/__init__.py
@@ -1,3 +1,10 @@
+import os
+
+# Improve performance and reproducibility
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+
 from vivarium.core.registry import (
     divider_registry,
     emitter_registry,

--- a/ecoli/composites/ecoli_master.py
+++ b/ecoli/composites/ecoli_master.py
@@ -857,6 +857,6 @@ test_library = {
 }
 
 # run experiments in test_library from the command line with:
-# uv run --env-file .env ecoli/composites/ecoli_master.py -n [experiment id]
+# uv run ecoli/composites/ecoli_master.py -n [experiment id]
 if __name__ == "__main__":
     run_library_cli(test_library)

--- a/ecoli/composites/ecoli_master_tests.py
+++ b/ecoli/composites/ecoli_master_tests.py
@@ -217,7 +217,7 @@ def test_lattice_lysis(plot=False):
     """
     Run plots:
     '''
-    > uv run --env-file .env ecoli/composites/ecoli_master_tests.py -n 4 -o plot=True
+    > uv run ecoli/composites/ecoli_master_tests.py -n 4 -o plot=True
     '''
 
     ANTIBIOTIC_KEY = 'nitrocefin'
@@ -287,6 +287,6 @@ test_library = {
 }
 
 # run experiments in test_library from the command line with:
-# uv run --env-file .env ecoli/composites/ecoli_master_tests.py -n [experiment id]
+# uv run ecoli/composites/ecoli_master_tests.py -n [experiment id]
 if __name__ == "__main__":
     run_library_cli(test_library)

--- a/ecoli/composites/environment/lattice.py
+++ b/ecoli/composites/environment/lattice.py
@@ -281,6 +281,6 @@ def main():
     )
 
 
-# uv run --env-file .env ecoli/composites/environment/lattice.py [-e if exchanges on]
+# uv run ecoli/composites/environment/lattice.py [-e if exchanges on]
 if __name__ == "__main__":
     main()

--- a/ecoli/experiments/antibiotics_tests.py
+++ b/ecoli/experiments/antibiotics_tests.py
@@ -126,6 +126,6 @@ library = {
     "2": test_lysis_rxn_dff_environment,
 }
 
-# uv run --env-file .env ecoli/experiments/antibiotics_tests.py -n library_id
+# uv run ecoli/experiments/antibiotics_tests.py -n library_id
 if __name__ == "__main__":
     run_library_cli(library)

--- a/ecoli/processes/environment/diffusion_field.py
+++ b/ecoli/processes/environment/diffusion_field.py
@@ -336,7 +336,7 @@ def run_diffusion_field(config=None, total_time=100, filename="snapshots"):
     )
 
 
-# uv run --env-file .env ecoli/processes/environment/diffusion_field.py
+# uv run ecoli/processes/environment/diffusion_field.py
 if __name__ == "__main__":
     # test_all()
 

--- a/ecoli/processes/environment/lysis.py
+++ b/ecoli/processes/environment/lysis.py
@@ -423,6 +423,6 @@ def main():
     )
 
 
-# uv run --env-file .env ecoli/processes/environment/lysis.py
+# uv run ecoli/processes/environment/lysis.py
 if __name__ == "__main__":
     main()

--- a/ecoli/processes/environment/multibody_physics.py
+++ b/ecoli/processes/environment/multibody_physics.py
@@ -103,7 +103,7 @@ class Multibody(Process):
 
           .. code-block:: console
 
-              $ MPLBACKEND=TKAgg uv run --env-file .env vivarium/processes/snapshots.py
+              $ MPLBACKEND=TKAgg uv run vivarium/processes/snapshots.py
 
     Notes:
         * rotational diffusion in liquid medium with viscosity = 1 mPa.s: :math:`Dr = 3.5 \\pm0.3 rad^{2}/s`

--- a/ecoli/processes/environment/reaction_diffusion_field.py
+++ b/ecoli/processes/environment/reaction_diffusion_field.py
@@ -410,6 +410,6 @@ def main():
     )
 
 
-# uv run --env-file .env ecoli/processes/environment/reaction_diffusion_field.py
+# uv run ecoli/processes/environment/reaction_diffusion_field.py
 if __name__ == "__main__":
     main()

--- a/ecoli/processes/enzyme_kinetics.py
+++ b/ecoli/processes/enzyme_kinetics.py
@@ -173,6 +173,6 @@ def test_enzyme_kinetics(end_time=100):
     return data is not None
 
 
-# run module with uv run --env-file .env ecoli/processes/enzyme_kinetics.py
+# run module with uv run ecoli/processes/enzyme_kinetics.py
 if __name__ == "__main__":
     test_enzyme_kinetics()

--- a/ecoli/processes/listeners/monomer_counts.py
+++ b/ecoli/processes/listeners/monomer_counts.py
@@ -239,6 +239,6 @@ def test_monomer_counts_listener():
     assert isinstance(listeners["monomer_counts"][1], list)
 
 
-# uv run --env-file .env ecoli/processes/listeners/monomer_counts.py
+# uv run ecoli/processes/listeners/monomer_counts.py
 if __name__ == "__main__":
     test_monomer_counts_listener()

--- a/migration/__init__.py
+++ b/migration/__init__.py
@@ -1,3 +1,10 @@
+import os
+
+# Improve performance and reproducibility
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+
 from ecoli.library.sim_data import LoadSimData, SIM_DATA_PATH, SIM_DATA_PATH_NO_OPERONS
 
 LOAD_SIM_DATA = LoadSimData(sim_data_path=SIM_DATA_PATH, seed=0)

--- a/reconstruction/__init__.py
+++ b/reconstruction/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+# Improve performance and reproducibility
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"

--- a/runscripts/__init__.py
+++ b/runscripts/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+# Improve performance and reproducibility
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"

--- a/runscripts/container/interactive.sh
+++ b/runscripts/container/interactive.sh
@@ -47,7 +47,7 @@ if (( $USE_APPTAINER )); then
     fi
     echo "=== Launching Apptainer container from ${WCM_IMAGE} ==="
     # Start Apptainer container with bind mounts
-    apptainer shell -e --writable-tmpfs ${BIND_CWD} ${WCM_IMAGE}
+    apptainer exec -e --writable-tmpfs ${BIND_CWD} ${WCM_IMAGE} bash -c "uv sync --frozen && bash"
 else
     # Docker-specific logic
     # Get GCP project name and region to construct image path

--- a/runscripts/container/wholecell/Dockerfile
+++ b/runscripts/container/wholecell/Dockerfile
@@ -24,11 +24,11 @@
 #
 # It will start a shell where you can execute commands:
 #
-#     uv run --env-file .env pytest
+#     uv run pytest
 #
 # If this succeeds you can start running WCM code in the container, e.g.:
 #
-#     uv run --env-file .env runscripts/manual/runParca.py
+#     uv run runscripts/manual/runParca.py
 
 ARG from=wcm-runtime:latest
 FROM ${from}

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+# Improve performance and reproducibility
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"

--- a/wholecell/__init__.py
+++ b/wholecell/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+# Improve performance and reproducibility
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"

--- a/wholecell/tests/utils/test_memory_debug.py
+++ b/wholecell/tests/utils/test_memory_debug.py
@@ -1,7 +1,7 @@
 """Test the memory_debug utility.
 
 Running it this way reveals the stdout messages about MemoryDebugNode IDs:
-        uv run --env-file .env python -m wholecell.tests.utils.test_memory_debug
+        uv run python -m wholecell.tests.utils.test_memory_debug
 
 In any case, you should see GC messages like:
         gc: uncollectable <MemoryDebugNode 0x110118050>


### PR DESCRIPTION
We have always set environment variables to force BLAS/LAPACK to use 1 thread for performance and reproducibility reasons. Instead of having users do this manually with `export ...` or `uv run --env-file .env`, we can do it programmatically in the `__init__.py` files of all modules.

The other tweak automatically installs the vEcoli package for interactive containers on Sherlock. This means users no longer have to manually set the `PYTHONPATH` and guarantees that the required Cython modules are compiled.