### PR TITLE
uv 0.5.21 no longer requires explicit CC

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -13,7 +13,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-          version: "0.5.7"
+          version: "0.5.21"
       - name: Install Pandoc
         run: sudo apt-get install pandoc
       - name: Install model

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-          version: "0.5.7"
+          version: "0.5.21"
       - name: Install Pandoc
         run: sudo apt-get install pandoc
       - name: Install model

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -17,7 +17,7 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
-        version: "0.5.7"
+        version: "0.5.21"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen
     - name: Test ParCa reproducibility
@@ -46,7 +46,7 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
-        version: "0.5.7"
+        version: "0.5.21"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen
     - name: Install nextflow edge

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
-        version: "0.5.7"
+        version: "0.5.21"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Test with pytest
@@ -44,7 +44,7 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
-        version: "0.5.7"
+        version: "0.5.21"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Mypy
@@ -58,7 +58,7 @@ jobs:
       uses: astral-sh/setup-uv@v4
       with:
         enable-cache: true
-        version: "0.5.7"
+        version: "0.5.21"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Ruff

--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Navigate into the cloned repository and use `uv` to install the model:
     cd vEcoli
     uv sync --frozen
 
-> **Note:** If your C compiler is not `clang`, run `CC={your compiler} uv sync --frozen`
-> instead to work around [this limitation](https://github.com/astral-sh/uv/issues/8429).
-> For example, `CC=gcc uv sync --frozen` for `gcc`.
-
 Finally, install `nextflow` [following these instructions](https://www.nextflow.io/docs/latest/install.html).
 If you choose to install Java with SDKMAN!, after the Java installation
 finishes, close and reopen your terminal before continuing with the

--- a/runscripts/container/runtime/Dockerfile
+++ b/runscripts/container/runtime/Dockerfile
@@ -11,7 +11,7 @@
 # Add option `--build-arg from=ABC` to build from a different base image "ABC"
 # but DO NOT USE an alpine base since the simulation math comes out different!
 # See https://pythonspeed.com/articles/alpine-docker-python/ for more reasons.
-ARG from=ghcr.io/astral-sh/uv:0.5.7-python3.12-bookworm-slim@sha256:444d948934bdb22e3204317842be6e1ad454cfa85103287a2ed18e471ede1f5b
+ARG from=ghcr.io/astral-sh/uv:0.5.21-python3.12-bookworm-slim@sha256:d7758d4b7176a067f7ae48239b44a8ebe9c16b00d1ec53867d41317a72e59717
 FROM ${from}
 
 RUN echo "alias ls='ls --color=auto'" >> ~/.bashrc \
@@ -33,7 +33,7 @@ ENV UV_COMPILE_BYTECODE=1
 
 COPY uv.lock pyproject.toml /vEcoli/
 # Install the project's dependencies using the lockfile and settings
-RUN CC=gcc uv sync --frozen --no-install-project --no-dev
+RUN uv sync --frozen --no-install-project --no-dev
 
 # Place executables in the environment at the front of the path
 ENV PATH="/vEcoli/.venv/bin:$PATH"

--- a/runscripts/container/runtime/Singularity
+++ b/runscripts/container/runtime/Singularity
@@ -1,11 +1,10 @@
 Bootstrap: docker
-From: ghcr.io/astral-sh/uv@sha256:444d948934bdb22e3204317842be6e1ad454cfa85103287a2ed18e471ede1f5b
+From: ghcr.io/astral-sh/uv@sha256:d7758d4b7176a067f7ae48239b44a8ebe9c16b00d1ec53867d41317a72e59717
 
 %environment
     export OPENBLAS_NUM_THREADS=1
     export PATH="/vEcoli/.venv/bin:$PATH"
     export UV_PROJECT_ENVIRONMENT="/vEcoli/.venv"
-    export CC=gcc
 
 %labels
     application "Whole Cell Model Runtime Environment"
@@ -27,7 +26,7 @@ From: ghcr.io/astral-sh/uv@sha256:444d948934bdb22e3204317842be6e1ad454cfa8510328
 
     apt-get update && apt-get install -y git gcc procps
 
-    UV_COMPILE_BYTECODE=1 CC=gcc uv sync --frozen --no-install-project --no-dev --project vEcoli
+    UV_COMPILE_BYTECODE=1 uv sync --frozen --no-install-project --no-dev --project vEcoli
 
 %runscript
     # This defines the default behavior when the container is executed.

--- a/runscripts/container/wholecell/Dockerfile
+++ b/runscripts/container/wholecell/Dockerfile
@@ -51,7 +51,7 @@ LABEL application="Whole Cell Model of Escherichia coli" \
 COPY . /vEcoli
 WORKDIR /vEcoli
 
-RUN CC=gcc uv sync --frozen
+RUN uv sync --frozen
 
 # Since this build runs as root, set permissions so running the container as
 # another user will work: Parca writes into /vEcoli/cache/.


### PR DESCRIPTION
Recent versions of uv no longer require the `CC` environment variable to be manually set for non-Clang C compilers. This results in a simpler and more robust setup process.