### PR TITLE
[Critical Bug] Update has_triggered_division before division

### DIFF
--- a/ecoli/composites/ecoli_master.py
+++ b/ecoli/composites/ecoli_master.py
@@ -480,7 +480,11 @@ class Ecoli(Composer):
                 flow["mark_d_period"] = [
                     (f"unique_update_{unique_update_counter - 1}",)
                 ]
-                flow["division"] = [("mark_d_period",)]
+                # Need additional UniqueUpdate layer to update full chromosome attributes
+                # after MarkDPeriod but before Division
+                steps[f"unique_update_{unique_update_counter}"] = UniqueUpdate(params)
+                flow[f"unique_update_{unique_update_counter}"] = [("mark_d_period",)]
+                flow["division"] = [(f"unique_update_{unique_update_counter}",)]
             else:
                 flow["division"] = [(f"unique_update_{unique_update_counter - 1}",)]
 


### PR DESCRIPTION
`MarkDPeriod` is supposed to update the `has_triggered_division` attribute of a full chromosome when it triggers division, preventing it from triggering division again. This was not happening because I forgot to include a `UniqueUpdate` step after `MarkDPeriod`.

This is really bad as it means that division will happen as soon as a cell has 2 complete chromosomes, skipping the D period. I only discovered this bug because some anaerobic simulations were reaching division with more than 2 full chromosomes, spawning at least one daughter cell that would immediately try to divide again.