### PR TITLE
Dependabot only for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     rebase-strategy: "auto"
     commit-message:
       prefix: "chore(deps): update"


### PR DESCRIPTION
Configure Dependabot to only create PRs for security updates.