### PR TITLE
Add Jenkinsfiles

### DIFF
--- a/runscripts/jenkins/Jenkinsfile/anaerobic
+++ b/runscripts/jenkins/Jenkinsfile/anaerobic
@@ -1,0 +1,47 @@
+pipeline {
+    agent any
+    
+    triggers {
+        cron('H H * * *')
+    }
+    
+    stages {
+        stage('Anaerobic') {
+            steps {
+                sh '''
+                TIMEOUT='12h'
+                code=0
+                timeout $TIMEOUT sh runscripts/jenkins/workflow.sh runscripts/jenkins/configs/ecoli-anaerobic.json || code=$?
+                [ $code -eq 124 ] && echo "Jenkins job timeout after $TIMEOUT"
+                exit $code
+                '''
+            }
+        }
+    }
+    
+    post {        
+        success {
+            slackSend(
+                color: 'good',
+                channel: '#jenkins',
+                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        failure {
+            slackSend(
+                color: 'danger',
+                channel: '#jenkins',
+                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        aborted {
+            slackSend(
+                color: '#808080',
+                channel: '#jenkins',
+                message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+    }
+}

--- a/runscripts/jenkins/Jenkinsfile/anaerobic
+++ b/runscripts/jenkins/Jenkinsfile/anaerobic
@@ -4,8 +4,26 @@ pipeline {
     triggers {
         cron('H H * * *')
     }
+
+    options {
+        // Configure shallow clone
+        skipDefaultCheckout(true)
+    }
     
     stages {
+        stage('Checkout') {
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: scm.branches,
+                    extensions: [
+                        [$class: 'CloneOption', depth: 1, noTags: false, shallow: true, reference: '']
+                    ],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                ])
+            }
+        }
+
         stage('Anaerobic') {
             steps {
                 sh '''
@@ -42,6 +60,10 @@ pipeline {
                 channel: '#jenkins',
                 message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
             )
+        }
+
+        cleanup {
+            cleanWs()
         }
     }
 }

--- a/runscripts/jenkins/Jenkinsfile/glucose
+++ b/runscripts/jenkins/Jenkinsfile/glucose
@@ -4,8 +4,26 @@ pipeline {
     triggers {
         cron('H H * * *')
     }
-    
+
+    options {
+        // Configure shallow clone
+        skipDefaultCheckout(true)
+    }
+
     stages {
+        stage('Checkout') {
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: scm.branches,
+                    extensions: [
+                        [$class: 'CloneOption', depth: 1, noTags: false, shallow: true, reference: '']
+                    ],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                ])
+            }
+        }
+
         stage('Glucose Minimal') {
             steps {
                 sh '''
@@ -42,6 +60,10 @@ pipeline {
                 channel: '#jenkins',
                 message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
             )
+        }
+
+        cleanup {
+            cleanWs()
         }
     }
 }

--- a/runscripts/jenkins/Jenkinsfile/glucose
+++ b/runscripts/jenkins/Jenkinsfile/glucose
@@ -1,0 +1,47 @@
+pipeline {
+    agent any
+    
+    triggers {
+        cron('H H * * *')
+    }
+    
+    stages {
+        stage('Glucose Minimal') {
+            steps {
+                sh '''
+                TIMEOUT='15h'
+                code=0
+                timeout $TIMEOUT sh runscripts/jenkins/workflow.sh runscripts/jenkins/configs/ecoli-glucose-minimal.json || code=$?
+                [ $code -eq 124 ] && echo "Jenkins job timeout after $TIMEOUT"
+                exit $code
+                '''
+            }
+        }
+    }
+    
+    post {        
+        success {
+            slackSend(
+                color: 'good',
+                channel: '#jenkins',
+                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        failure {
+            slackSend(
+                color: 'danger',
+                channel: '#jenkins',
+                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        aborted {
+            slackSend(
+                color: '#808080',
+                channel: '#jenkins',
+                message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+    }
+}

--- a/runscripts/jenkins/Jenkinsfile/optional
+++ b/runscripts/jenkins/Jenkinsfile/optional
@@ -1,0 +1,54 @@
+pipeline {
+    agent any
+    
+    triggers {
+        cron('H H * * *')
+    }
+    
+    stages {
+        stage('Anaerobic') {
+            steps {
+                sh '''
+                TIMEOUT='18h'
+                code=0
+                timeout $TIMEOUT sh runscripts/jenkins/workflow.sh \
+                    runscripts/jenkins/configs/ecoli-no-growth-rate-control.json && 
+                    sh runscripts/jenkins/workflow.sh \
+                    runscripts/jenkins/configs/ecoli-no-operons.json && 
+                    sh runscripts/jenkins/workflow.sh \
+                    runscripts/jenkins/configs/ecoli-new-gene-gfp.json && 
+                    sh runscripts/jenkins/workflow.sh \
+                    runscripts/jenkins/configs/ecoli-superhelical-density.json || code=$?
+                [ $code -eq 124 ] && echo "Jenkins job timeout after $TIMEOUT"
+                exit $code
+                '''
+            }
+        }
+    }
+    
+    post {        
+        success {
+            slackSend(
+                color: 'good',
+                channel: '#jenkins',
+                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        failure {
+            slackSend(
+                color: 'danger',
+                channel: '#jenkins',
+                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        aborted {
+            slackSend(
+                color: '#808080',
+                channel: '#jenkins',
+                message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+    }
+}

--- a/runscripts/jenkins/Jenkinsfile/optional
+++ b/runscripts/jenkins/Jenkinsfile/optional
@@ -4,9 +4,27 @@ pipeline {
     triggers {
         cron('H H * * *')
     }
+
+    options {
+        // Configure shallow clone
+        skipDefaultCheckout(true)
+    }
     
     stages {
-        stage('Anaerobic') {
+        stage('Checkout') {
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: scm.branches,
+                    extensions: [
+                        [$class: 'CloneOption', depth: 1, noTags: false, shallow: true, reference: '']
+                    ],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                ])
+            }
+        }
+
+        stage('Optional Features') {
             steps {
                 sh '''
                 TIMEOUT='18h'
@@ -49,6 +67,10 @@ pipeline {
                 channel: '#jenkins',
                 message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
             )
+        }
+
+        cleanup {
+            cleanWs()
         }
     }
 }

--- a/runscripts/jenkins/Jenkinsfile/with_aas
+++ b/runscripts/jenkins/Jenkinsfile/with_aas
@@ -1,0 +1,47 @@
+pipeline {
+    agent any
+    
+    triggers {
+        cron('H H * * *')
+    }
+    
+    stages {
+        stage('Anaerobic') {
+            steps {
+                sh '''
+                TIMEOUT='12h'
+                code=0
+                timeout $TIMEOUT sh runscripts/jenkins/workflow.sh runscripts/jenkins/configs/ecoli-with-aa.json || code=$?
+                [ $code -eq 124 ] && echo "Jenkins job timeout after $TIMEOUT"
+                exit $code
+                '''
+            }
+        }
+    }
+    
+    post {        
+        success {
+            slackSend(
+                color: 'good',
+                channel: '#jenkins',
+                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        failure {
+            slackSend(
+                color: 'danger',
+                channel: '#jenkins',
+                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+        
+        aborted {
+            slackSend(
+                color: '#808080',
+                channel: '#jenkins',
+                message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
+            )
+        }
+    }
+}

--- a/runscripts/jenkins/Jenkinsfile/with_aas
+++ b/runscripts/jenkins/Jenkinsfile/with_aas
@@ -4,9 +4,27 @@ pipeline {
     triggers {
         cron('H H * * *')
     }
+
+    options {
+        // Configure shallow clone
+        skipDefaultCheckout(true)
+    }
     
     stages {
-        stage('Anaerobic') {
+        stage('Checkout') {
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: scm.branches,
+                    extensions: [
+                        [$class: 'CloneOption', depth: 1, noTags: false, shallow: true, reference: '']
+                    ],
+                    userRemoteConfigs: scm.userRemoteConfigs
+                ])
+            }
+        }
+
+        stage('With AAs') {
             steps {
                 sh '''
                 TIMEOUT='12h'
@@ -42,6 +60,10 @@ pipeline {
                 channel: '#jenkins',
                 message: ":stop_button: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
             )
+        }
+
+        cleanup {
+            cleanWs()
         }
     }
 }

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import random
 import shutil
 import subprocess
 import warnings
@@ -363,6 +364,9 @@ def main():
     # Resolve sim_data_path if provided
     if config["sim_data_path"] is not None:
         config["sim_data_path"] = os.path.abspath(config["sim_data_path"])
+    # Use random seed for Jenkins CI runs
+    if config.get("sherlock", {}).get("jenkins", False):
+        config["lineage_seed"] = random.randint(0, 2**31 - 1)
     filesystem, outdir = fs.FileSystem.from_uri(out_uri)
     outdir = os.path.join(outdir, experiment_id, "nextflow")
     out_uri = os.path.join(out_uri, experiment_id, "nextflow")


### PR DESCRIPTION
Include the Jenkins CI pipelines in the repo. This improves transparency and also lets me use GitHub App-based authentication instead of a machine account, improving security.

Also, start test different random seeds each time we run a Jenkins workflow.