### PR TITLE
Print all log lines as soon as available

### DIFF
--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -358,7 +358,7 @@ def forward_sbatch_output(
             ).stdout.strip()
 
             # Check for output from tail process
-            if poller.poll(100):
+            while poller.poll(100):
                 line = tail_stdout.readline()
                 if line:
                     print(line, end="", flush=True)


### PR DESCRIPTION
Fix oversight where data from log file would only be forwarded to the main process stdout one line at a time.