### PR TITLE
Make sure both simulations finish before comparing outputs

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -41,6 +41,7 @@ jobs:
             --generations 1 --emitter parquet --emitter_arg out_dir='out' \
             --experiment_id "parca_2" --daughter_outdir "out/parca_2" \
             --sim_data_path "out/parca_2/kb/simData.cPickle" --fail_at_total_time
+        fg
         uv run --env-file .env runscripts/debug/diff_simouts.py -o "out" "parca_1*" "parca_2*"
   Two-gens:
     runs-on: macos-latest

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -2,6 +2,10 @@
 
 name: Workflow
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: read
   pull-requests: write
@@ -33,6 +37,8 @@ jobs:
         uv run --env-file .env runscripts/debug/compare_pickles.py out/parca_1/kb out/parca_2/kb
     - name: Test simulation reproducibility
       run: |
+        # Enable job control so "fg" works
+        set -m
         uv run --env-file .env ecoli/experiments/ecoli_master_sim.py \
             --generations 1 --emitter parquet --emitter_arg out_dir='out' \
             --experiment_id "parca_1" --daughter_outdir "out/parca_1" \


### PR DESCRIPTION
One of the simulations in this GitHub Action test for simulation reproducibility is started in the background (using `&`). Occasionally, this simulation does not finish writing its output files before the next command runs to compare simulation outputs. Bringing this simulation back to the foreground allows it to finish before running any other commands.