### PR TITLE
Jenkins Slack notifications only for unsuccessful runs

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -37,17 +37,22 @@ jobs:
         uv run --env-file .env runscripts/debug/compare_pickles.py out/parca_1/kb out/parca_2/kb
     - name: Test simulation reproducibility
       run: |
-        # Enable job control so "fg" works
-        set -m
         uv run --env-file .env ecoli/experiments/ecoli_master_sim.py \
             --generations 1 --emitter parquet --emitter_arg out_dir='out' \
             --experiment_id "parca_1" --daughter_outdir "out/parca_1" \
             --sim_data_path "out/parca_1/kb/simData.cPickle" --fail_at_total_time &
+        SIM1_PID=$!
         uv run --env-file .env ecoli/experiments/ecoli_master_sim.py \
             --generations 1 --emitter parquet --emitter_arg out_dir='out' \
             --experiment_id "parca_2" --daughter_outdir "out/parca_2" \
             --sim_data_path "out/parca_2/kb/simData.cPickle" --fail_at_total_time
-        fg
+        # Wait for the first simulation to complete if it's still running
+        if ps -p $SIM1_PID > /dev/null; then
+          echo "Waiting for first simulation (PID: $SIM1_PID) to complete..."
+          wait $SIM1_PID
+        else
+          echo "First simulation already completed"
+        fi
         uv run --env-file .env runscripts/debug/diff_simouts.py -o "out" "parca_1*" "parca_2*"
   Two-gens:
     runs-on: macos-latest

--- a/runscripts/jenkins/Jenkinsfile/anaerobic
+++ b/runscripts/jenkins/Jenkinsfile/anaerobic
@@ -39,62 +39,70 @@ pipeline {
     
     post {        
         success {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'good',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                echo "Job was successful just like last run, not sending Slack notification."
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'good',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    echo "Job was successful just like last run, not sending Slack notification."
+                }
             }
         }
         
         failure {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
         
         aborted {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 
         unstable {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 

--- a/runscripts/jenkins/Jenkinsfile/anaerobic
+++ b/runscripts/jenkins/Jenkinsfile/anaerobic
@@ -43,7 +43,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -55,13 +55,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -71,13 +71,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -87,13 +87,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }

--- a/runscripts/jenkins/Jenkinsfile/anaerobic
+++ b/runscripts/jenkins/Jenkinsfile/anaerobic
@@ -39,31 +39,78 @@ pipeline {
     
     post {        
         success {
-            slackSend(
-                color: 'good',
-                channel: '#jenkins',
-                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'good',
+                    channel: '#jenkins',
+                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                echo "Job was successful just like last run, not sending Slack notification."
+            }
         }
         
         failure {
-            slackSend(
-                color: 'danger',
-                channel: '#jenkins',
-                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
         
         aborted {
-            slackSend(
-                color: '#808080',
-                channel: '#jenkins',
-                message: ":octagonal_sign: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
+        }
+
+        unstable {
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
 
         cleanup {
             cleanWs()
         }
     }
+}
+
+def hasStatusChanged() {
+    if (currentBuild.previousBuild == null) {
+        return true
+    }
+    
+    def previousResult = currentBuild.previousBuild.result
+    def currentResult = currentBuild.currentResult
+    
+    return previousResult != currentResult
 }

--- a/runscripts/jenkins/Jenkinsfile/anaerobic
+++ b/runscripts/jenkins/Jenkinsfile/anaerobic
@@ -43,7 +43,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -55,13 +55,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -71,13 +71,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -87,13 +87,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }

--- a/runscripts/jenkins/Jenkinsfile/glucose
+++ b/runscripts/jenkins/Jenkinsfile/glucose
@@ -39,62 +39,70 @@ pipeline {
     
     post {        
         success {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'good',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                echo "Job was successful just like last run, not sending Slack notification."
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'good',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    echo "Job was successful just like last run, not sending Slack notification."
+                }
             }
         }
         
         failure {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
         
         aborted {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 
         unstable {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 

--- a/runscripts/jenkins/Jenkinsfile/glucose
+++ b/runscripts/jenkins/Jenkinsfile/glucose
@@ -43,7 +43,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -55,13 +55,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -71,13 +71,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -87,13 +87,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }

--- a/runscripts/jenkins/Jenkinsfile/glucose
+++ b/runscripts/jenkins/Jenkinsfile/glucose
@@ -39,31 +39,78 @@ pipeline {
     
     post {        
         success {
-            slackSend(
-                color: 'good',
-                channel: '#jenkins',
-                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'good',
+                    channel: '#jenkins',
+                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                echo "Job was successful just like last run, not sending Slack notification."
+            }
         }
         
         failure {
-            slackSend(
-                color: 'danger',
-                channel: '#jenkins',
-                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
         
         aborted {
-            slackSend(
-                color: '#808080',
-                channel: '#jenkins',
-                message: ":octagonal_sign: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
+        }
+
+        unstable {
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
 
         cleanup {
             cleanWs()
         }
     }
+}
+
+def hasStatusChanged() {
+    if (currentBuild.previousBuild == null) {
+        return true
+    }
+    
+    def previousResult = currentBuild.previousBuild.result
+    def currentResult = currentBuild.currentResult
+    
+    return previousResult != currentResult
 }

--- a/runscripts/jenkins/Jenkinsfile/glucose
+++ b/runscripts/jenkins/Jenkinsfile/glucose
@@ -43,7 +43,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -55,13 +55,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -71,13 +71,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -87,13 +87,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }

--- a/runscripts/jenkins/Jenkinsfile/optional
+++ b/runscripts/jenkins/Jenkinsfile/optional
@@ -46,62 +46,70 @@ pipeline {
     
     post {        
         success {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'good',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                echo "Job was successful just like last run, not sending Slack notification."
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'good',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    echo "Job was successful just like last run, not sending Slack notification."
+                }
             }
         }
         
         failure {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
         
         aborted {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 
         unstable {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 

--- a/runscripts/jenkins/Jenkinsfile/optional
+++ b/runscripts/jenkins/Jenkinsfile/optional
@@ -50,7 +50,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -62,13 +62,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -78,13 +78,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -94,13 +94,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }

--- a/runscripts/jenkins/Jenkinsfile/optional
+++ b/runscripts/jenkins/Jenkinsfile/optional
@@ -50,7 +50,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -62,13 +62,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -78,13 +78,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -94,13 +94,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }

--- a/runscripts/jenkins/Jenkinsfile/optional
+++ b/runscripts/jenkins/Jenkinsfile/optional
@@ -46,31 +46,78 @@ pipeline {
     
     post {        
         success {
-            slackSend(
-                color: 'good',
-                channel: '#jenkins',
-                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'good',
+                    channel: '#jenkins',
+                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                echo "Job was successful just like last run, not sending Slack notification."
+            }
         }
         
         failure {
-            slackSend(
-                color: 'danger',
-                channel: '#jenkins',
-                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
         
         aborted {
-            slackSend(
-                color: '#808080',
-                channel: '#jenkins',
-                message: ":octagonal_sign: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
+        }
+
+        unstable {
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
 
         cleanup {
             cleanWs()
         }
     }
+}
+
+def hasStatusChanged() {
+    if (currentBuild.previousBuild == null) {
+        return true
+    }
+    
+    def previousResult = currentBuild.previousBuild.result
+    def currentResult = currentBuild.currentResult
+    
+    return previousResult != currentResult
 }

--- a/runscripts/jenkins/Jenkinsfile/with_aas
+++ b/runscripts/jenkins/Jenkinsfile/with_aas
@@ -39,62 +39,70 @@ pipeline {
     
     post {        
         success {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'good',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                echo "Job was successful just like last run, not sending Slack notification."
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'good',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    echo "Job was successful just like last run, not sending Slack notification."
+                }
             }
         }
         
         failure {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'danger',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'danger',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
         
         aborted {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: '#808080',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: '#808080',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 
         unstable {
-            if (hasStatusChanged()) {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
-            } else {
-                slackSend(
-                    color: 'warning',
-                    channel: '#jenkins',
-                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
-                )
+            script {
+                if (hasStatusChanged()) {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                } else {
+                    slackSend(
+                        color: 'warning',
+                        channel: '#jenkins',
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    )
+                }
             }
         }
 

--- a/runscripts/jenkins/Jenkinsfile/with_aas
+++ b/runscripts/jenkins/Jenkinsfile/with_aas
@@ -43,7 +43,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -55,13 +55,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -71,13 +71,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -87,13 +87,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }

--- a/runscripts/jenkins/Jenkinsfile/with_aas
+++ b/runscripts/jenkins/Jenkinsfile/with_aas
@@ -39,31 +39,78 @@ pipeline {
     
     post {        
         success {
-            slackSend(
-                color: 'good',
-                channel: '#jenkins',
-                message: ":white_check_mark: *SUCCESS:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' completed successfully.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'good',
+                    channel: '#jenkins',
+                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                echo "Job was successful just like last run, not sending Slack notification."
+            }
         }
         
         failure {
-            slackSend(
-                color: 'danger',
-                channel: '#jenkins',
-                message: ":x: *FAILURE:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' failed.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'danger',
+                    channel: '#jenkins',
+                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
         
         aborted {
-            slackSend(
-                color: '#808080',
-                channel: '#jenkins',
-                message: ":octagonal_sign: *ABORTED:* Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' was aborted.\nTime: ${currentBuild.durationString}\n${env.BUILD_URL}"
-            )
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: '#808080',
+                    channel: '#jenkins',
+                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
+        }
+
+        unstable {
+            if (hasStatusChanged()) {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            } else {
+                slackSend(
+                    color: 'warning',
+                    channel: '#jenkins',
+                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                )
+            }
         }
 
         cleanup {
             cleanWs()
         }
     }
+}
+
+def hasStatusChanged() {
+    if (currentBuild.previousBuild == null) {
+        return true
+    }
+    
+    def previousResult = currentBuild.previousBuild.result
+    def currentResult = currentBuild.currentResult
+    
+    return previousResult != currentResult
 }

--- a/runscripts/jenkins/Jenkinsfile/with_aas
+++ b/runscripts/jenkins/Jenkinsfile/with_aas
@@ -43,7 +43,7 @@ pipeline {
                 slackSend(
                     color: 'good',
                     channel: '#jenkins',
-                    message: ":white_check_mark: ${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 echo "Job was successful just like last run, not sending Slack notification."
@@ -55,13 +55,13 @@ pipeline {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'danger',
                     channel: '#jenkins',
-                    message: ":x: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -71,13 +71,13 @@ pipeline {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: '#808080',
                     channel: '#jenkins',
-                    message: ":octagonal_sign: ${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }
@@ -87,13 +87,13 @@ pipeline {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             } else {
                 slackSend(
                     color: 'warning',
                     channel: '#jenkins',
-                    message: ":warning: ${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                    message: "${env.JOB_NAME} #${env.BUILD_NUMBER} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
                 )
             }
         }


### PR DESCRIPTION
Add logic to match previous behavior of Jenkins Slack notifications:

- Only notify for unsuccessful jobs and when they return back to normal
- Remove redundant emoji
- Use hyperlink instead of full URL

Also, fix a new issue I introduced in #289 of `fg` raising an error if the background simulation in our GitHub Actions reproducibility test has already completed. This PR adds new logic to wait for the background simulation that should be more robust.