### PR TITLE
Fix SLURM job output forwarding

### DIFF
--- a/runscripts/jenkins/Jenkinsfile/anaerobic
+++ b/runscripts/jenkins/Jenkinsfile/anaerobic
@@ -44,7 +44,7 @@ pipeline {
                     slackSend(
                         color: 'good',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     echo "Job was successful just like last run, not sending Slack notification."
@@ -58,13 +58,13 @@ pipeline {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -76,13 +76,13 @@ pipeline {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -94,13 +94,13 @@ pipeline {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }

--- a/runscripts/jenkins/Jenkinsfile/glucose
+++ b/runscripts/jenkins/Jenkinsfile/glucose
@@ -44,7 +44,7 @@ pipeline {
                     slackSend(
                         color: 'good',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     echo "Job was successful just like last run, not sending Slack notification."
@@ -58,13 +58,13 @@ pipeline {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -76,13 +76,13 @@ pipeline {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -94,13 +94,13 @@ pipeline {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }

--- a/runscripts/jenkins/Jenkinsfile/optional
+++ b/runscripts/jenkins/Jenkinsfile/optional
@@ -51,7 +51,7 @@ pipeline {
                     slackSend(
                         color: 'good',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     echo "Job was successful just like last run, not sending Slack notification."
@@ -65,13 +65,13 @@ pipeline {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -83,13 +83,13 @@ pipeline {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -101,13 +101,13 @@ pipeline {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }

--- a/runscripts/jenkins/Jenkinsfile/with_aas
+++ b/runscripts/jenkins/Jenkinsfile/with_aas
@@ -44,7 +44,7 @@ pipeline {
                     slackSend(
                         color: 'good',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} back to normal after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     echo "Job was successful just like last run, not sending Slack notification."
@@ -58,13 +58,13 @@ pipeline {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} failed after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'danger',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still failing after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -76,13 +76,13 @@ pipeline {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: '#808080',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} aborted again after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }
@@ -94,13 +94,13 @@ pipeline {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 } else {
                     slackSend(
                         color: 'warning',
                         channel: '#jenkins',
-                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString} (<${env.BUILD_URL}|link>)"
+                        message: "${env.JOB_NAME} ${env.BUILD_DISPLAY_NAME} is still unstable after ${currentBuild.durationString.minus(' and counting')} (<${env.BUILD_URL}|link>)"
                     )
                 }
             }


### PR DESCRIPTION
Fixes the logic that forwards the output of SLURM jobs submitted by `workflow.py` to the stdout of the `workflow.py` process. This functionality mainly exists to allow Jenkins to build containers and run Nextflow processes in separate SLURM jobs (Jenkins job only has 1 CPU and 4GB RAM) while still publishing their stdout/stderr. With the updated logic, the forwarded output should now be within about a minute of real-time, which is good enough for our use case. 

Additionally, this removes the unnecessary `and counting` suffix from Jenkins Slack notifications.