### PR TITLE
Fix GCP debugging instructions

### DIFF
--- a/doc/gcloud.rst
+++ b/doc/gcloud.rst
@@ -264,10 +264,13 @@ inserting::
   
   import ipdb; ipdb.set_trace()
 
-Navigate to the working directory (see :ref:`troubleshooting`) of the failing
-task at ``/mnt/disks/{bucket}/...``. Evoke ``bash .command.sh`` to run the
-task. Execution should pause at your set breakpoints, allowing you to inspect
-variables and step through the code.
+Note the working directory (see :ref:`troubleshooting`) of the failing task
+(should be of the form ``/mnt/disks/{bucket}/...``). Inside the container, run::
+  
+  # Symlink files, including the script for the task (.command.sh)
+  bash {working directory}/.command.run nxf_stage
+  # Run the task
+  bash .command.sh
 
 .. warning::
   Any changes that you make to the code in ``/vEcoli`` inside the container are not

--- a/runscripts/nextflow/analysis.nf
+++ b/runscripts/nextflow/analysis.nf
@@ -18,7 +18,8 @@ process analysisSingle {
     script:
     """
     mkdir -p plots
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -68,7 +69,8 @@ process analysisMultiDaughter {
     script:
     """
     mkdir -p plots
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -116,7 +118,8 @@ process analysisMultiGeneration {
     script:
     """
     mkdir -p plots
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -162,7 +165,8 @@ process analysisMultiSeed {
     script:
     """
     mkdir -p plots
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -204,7 +208,8 @@ process analysisMultiVariant {
     script:
     """
     mkdir -p plots
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "${sim_data.join("\" \"")}" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\

--- a/runscripts/nextflow/colony.nf
+++ b/runscripts/nextflow/colony.nf
@@ -9,7 +9,9 @@ process colony {
 
     script:
     """
-    python /vEcoli/ecoli/experiments/ecoli_engine_process.py --config $config --sim_data_path $sim_data --initial_state_file $initial_state
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/ecoli/experiments/ecoli_engine_process.py \\
+        --config $config --sim_data_path $sim_data --initial_state_file $initial_state
     STATUS=$?
     """
 

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -25,8 +25,6 @@ profiles {
                 (((task.exitStatus == 137) || (task.exitStatus >= 50001 && task.exitStatus <= 50006))
                 && (task.attempt <= process.maxRetries)) ? 'retry' : 'ignore'
             }
-            // Ensure that symlinks are transferred over to bucket
-            stageOutMode = 'copy'
             // Retry once with more RAM if OOM
             memory = { 4.GB * task.attempt }
             maxRetries = 1

--- a/runscripts/nextflow/sim.nf
+++ b/runscripts/nextflow/sim.nf
@@ -26,7 +26,8 @@ process simGen0 {
     touch daughter_state_0.json
     touch daughter_state_1.json
     touch division_time.sh
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
         --config $config \\
         --sim_data_path $sim_data \\
         --daughter_outdir "\$(pwd)" \\
@@ -75,7 +76,8 @@ process sim {
     touch daughter_state_0.json
     touch daughter_state_1.json
     touch division_time.sh
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
         --config $config \\
         --sim_data_path $sim_data \\
         --initial_state_file ${initial_state.getBaseName()} \\

--- a/runscripts/nextflow/template.nf
+++ b/runscripts/nextflow/template.nf
@@ -12,7 +12,8 @@ process runParca {
 
     script:
     """
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/parca.py --config "$config" -o "\$(pwd)"
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/parca.py --config "$config" -o "\$(pwd)"
     """
 
     stub:
@@ -39,10 +40,11 @@ process analysisParca {
 
     script:
     """
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config "$config" \
-        --sim_data_path="$kb/simData.cPickle" \
-        --validation_data_path="$kb/validationData.cPickle" \
-        -o "\$(pwd)/plots" \
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/analysis.py --config $config \\
+        --sim_data_path="$kb/simData.cPickle" \\
+        --validation_data_path="$kb/validationData.cPickle" \\
+        -o "\$(pwd)/plots" \\
         -t parca
     """
 
@@ -69,7 +71,8 @@ process createVariants {
 
     script:
     """
-    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/create_variants.py \
+    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
+        ${params.projectRoot}/runscripts/create_variants.py \\
         --config "$config" --kb "$kb" -o "\$(pwd)"
     """
 


### PR DESCRIPTION
To debug a failing task on Google Cloud, the necessary files must first be symlinked into the current directory using the `.command.run` wrapper script for the task.

Additionally, this PR updates the Nextflow jobs to properly launch all scripts with `uv`.