### PR TITLE
Go back to calling python instead of uv in workflow jobs

### DIFF
--- a/runscripts/container/runtime/Singularity
+++ b/runscripts/container/runtime/Singularity
@@ -4,7 +4,6 @@ From: ghcr.io/astral-sh/uv@sha256:21051ff1d154bb559756e842d8b49f6e1f12cbbf75895b
 %environment
     export OPENBLAS_NUM_THREADS=1
     export PATH="/vEcoli/.venv/bin:$PATH"
-    export UV_PROJECT_ENVIRONMENT="/vEcoli/.venv"
 
 %labels
     application "Whole Cell Model Runtime Environment"

--- a/runscripts/nextflow/analysis.nf
+++ b/runscripts/nextflow/analysis.nf
@@ -18,8 +18,7 @@ process analysisSingle {
     script:
     """
     mkdir -p plots
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -69,8 +68,7 @@ process analysisMultiDaughter {
     script:
     """
     mkdir -p plots
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -118,8 +116,7 @@ process analysisMultiGeneration {
     script:
     """
     mkdir -p plots
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -165,8 +162,7 @@ process analysisMultiSeed {
     script:
     """
     mkdir -p plots
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "$sim_data" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\
@@ -208,8 +204,7 @@ process analysisMultiVariant {
     script:
     """
     mkdir -p plots
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/analysis.py --config $config \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config $config \\
         --sim_data_path "${sim_data.join("\" \"")}" \\
         --validation_data_path "$kb/validationData.cPickle" \\
         --experiment_id "$experiment_id" \\

--- a/runscripts/nextflow/colony.nf
+++ b/runscripts/nextflow/colony.nf
@@ -9,9 +9,7 @@ process colony {
 
     script:
     """
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/ecoli/experiments/ecoli_engine_process.py \\
-        --config $config --sim_data_path $sim_data --initial_state_file $initial_state
+    python /vEcoli/ecoli/experiments/ecoli_engine_process.py --config $config --sim_data_path $sim_data --initial_state_file $initial_state
     STATUS=$?
     """
 

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -80,7 +80,7 @@ profiles {
             }
             container = params.container_image
             containerOptions = "-B ${params.publishDir}:${params.publishDir} -B ${launchDir}:${launchDir}"
-            queue = 'mcovert,owners,normal'
+            queue = 'owners,normal'
             executor = 'slurm'
             // Single core sims are slightly slower but can have shorter
             // queue times and is less damaging to future job priority
@@ -134,7 +134,7 @@ profiles {
                 cpus = params.parca_cpus
                 memory = params.parca_cpus * 2.GB
                 executor = 'slurm'
-                queue = 'mcovert,owners,normal'
+                queue = 'owners,normal'
                 clusterOptions = ''
             }
             container = params.container_image

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -77,6 +77,13 @@ profiles {
             withLabel: parca {
                 cpus = params.parca_cpus
                 memory = params.parca_cpus * 2.GB
+                time = {
+                    if ( task.exitStatus == 140 ) {
+                        1.h * task.attempt
+                    } else {
+                        1.h
+                    }
+                }
             }
             container = params.container_image
             containerOptions = "-B ${params.publishDir}:${params.publishDir} -B ${launchDir}:${launchDir}"
@@ -136,6 +143,13 @@ profiles {
                 executor = 'slurm'
                 queue = 'owners,normal'
                 clusterOptions = ''
+                time = {
+                    if ( task.exitStatus == 140 ) {
+                        1.h * task.attempt
+                    } else {
+                        1.h
+                    }
+                }
             }
             container = params.container_image
             containerOptions = "-B ${params.publishDir}:${params.publishDir} -B ${launchDir}:${launchDir}"

--- a/runscripts/nextflow/sim.nf
+++ b/runscripts/nextflow/sim.nf
@@ -26,8 +26,7 @@ process simGen0 {
     touch daughter_state_0.json
     touch daughter_state_1.json
     touch division_time.sh
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
         --config $config \\
         --sim_data_path $sim_data \\
         --daughter_outdir "\$(pwd)" \\
@@ -76,8 +75,7 @@ process sim {
     touch daughter_state_0.json
     touch daughter_state_1.json
     touch division_time.sh
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/ecoli/experiments/ecoli_master_sim.py \\
         --config $config \\
         --sim_data_path $sim_data \\
         --initial_state_file ${initial_state.getBaseName()} \\

--- a/runscripts/nextflow/template.nf
+++ b/runscripts/nextflow/template.nf
@@ -12,8 +12,7 @@ process runParca {
 
     script:
     """
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/parca.py --config "$config" -o "\$(pwd)"
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/parca.py --config "$config" -o "\$(pwd)"
     """
 
     stub:
@@ -40,11 +39,10 @@ process analysisParca {
 
     script:
     """
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/analysis.py --config $config \\
-        --sim_data_path="$kb/simData.cPickle" \\
-        --validation_data_path="$kb/validationData.cPickle" \\
-        -o "\$(pwd)/plots" \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/analysis.py --config "$config" \
+        --sim_data_path="$kb/simData.cPickle" \
+        --validation_data_path="$kb/validationData.cPickle" \
+        -o "\$(pwd)/plots" \
         -t parca
     """
 
@@ -71,8 +69,7 @@ process createVariants {
 
     script:
     """
-    uv --project ${params.projectRoot} run --env-file ${params.projectRoot}/.env \\
-        ${params.projectRoot}/runscripts/create_variants.py \\
+    PYTHONPATH=${params.projectRoot} python ${params.projectRoot}/runscripts/create_variants.py \
         --config "$config" --kb "$kb" -o "\$(pwd)"
     """
 

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -531,7 +531,7 @@ def main():
 #SBATCH --time=01:00:00
 #SBATCH --cpus-per-task 2
 #SBATCH --mem=8GB
-#SBATCH --partition=mcovert,owners,normal
+#SBATCH --partition=owners,normal
 #SBATCH --output={os.path.join(local_outdir, "container.out")}
 {runtime_image_cmd}
 apptainer exec -B {repo_dir}:{repo_dir} \
@@ -610,7 +610,7 @@ hq server start --journal {os.path.join(outdir, ".hq-server/journal")} &
 until hq job list &>/dev/null ; do sleep 1 ; done
 
 # Enable HyperQueue automatic allocation
-hq alloc add slurm --time-limit 8h -- --partition=mcovert,owners,normal --mem=4GB
+hq alloc add slurm --time-limit 8h -- --partition=owners,normal --mem=4GB
 """
             hyperqueue_exit = "hq job wait all; hq worker stop all; hq server stop"
         nf_slurm_output = os.path.join(outdir, f"{experiment_id}_slurm.out")

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -528,7 +528,7 @@ def main():
             with open(container_build_script, "w") as f:
                 f.write(f"""#!/bin/bash
 #SBATCH --job-name="build-container-{experiment_id}"
-#SBATCH --time=01:00:00
+#SBATCH --time=30:00
 #SBATCH --cpus-per-task 2
 #SBATCH --mem=8GB
 #SBATCH --partition=owners,normal


### PR DESCRIPTION
Changing the Nextflow jobs to invoke `uv` instead of `python` (https://github.com/CovertLab/vEcoli/commit/95e4bd66740d63358cb33c295b7e26b8f4f1b1a5) broke containerized workflows because the container file system is read-only (`uv` tries to do an editable install of the project). Since we set the `PATH` variable to include the `uv` virtual environment in our container images and Nextflow jobs inherit the environment of the calling process, using `python` directly is fine.

Also, only use the lab's Sherlock partition for the Nextflow head job as it is the only job that requires the extended runtime limit and protection from preemption. This will likely lead to longer queue times, but this is greatly mitigated by HyperQueue and prevents one workflow from occupying all the cores available on our partition, preventing anyone else from starting a workflow.