### PR TITLE
Fix pip-audit GitHub Action

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -18,4 +18,6 @@ jobs:
           enable-cache: true
           version: "0.6.10"
       - name: Audit dependencies
-        run: uv run --all-extras --with pip-audit pip-audit -l
+        run:
+          uv export --all-extras --format requirements-txt --no-emit-project > requirements.txt && \
+          uvx pip-audit -r requirements.txt --disable-pip --fix


### PR DESCRIPTION
The `--with` option for `uv` does not work the way I thought it did and creates a virtual environment that includes only `pip-audit` and its dependencies, ignoring all the dependencies for vEcoli. This PR should fix that by explicitly generating a `requirements.txt` with all vEcoli dependencies for `pip-audit` to audit.