### PR TITLE
Tying up loose ends for Google Cloud containers

### DIFF
--- a/runscripts/container/cloud_build.json
+++ b/runscripts/container/cloud_build.json
@@ -1,22 +1,23 @@
 {
     "steps": [
-    {
-        "name": "gcr.io/cloud-builders/docker",
-        "args": [
-            "build",
-            "--build-arg", "git_hash=${_GIT_HASH}",
-            "--build-arg", "git_branch=${_GIT_BRANCH}",
-            "--build-arg", "timestamp=${_TIMESTAMP}",
-            "-t", "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_IMAGE}",
-            "-f", "runscripts/container/Dockerfile",
-            "."
-        ],
-        "env": [
-            "DOCKER_BUILDKIT=1"
-        ]
-    }
+        {
+            "name": "docker",
+            "args": [
+                "build",
+                "--build-arg", "git_hash=${_GIT_HASH}",
+                "--build-arg", "git_branch=${_GIT_BRANCH}",
+                "--build-arg", "timestamp=${_TIMESTAMP}",
+                "--cache-to", "type=inline",
+                "--cache-from", "type=registry,ref=${LOCATION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_IMAGE}:latest",
+                "-t", "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_IMAGE}:latest",
+                "-t", "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_IMAGE}:${_GIT_HASH}",
+                "-f", "runscripts/container/Dockerfile",
+                "."
+            ]
+        }
     ],
     "images": [
-        "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_IMAGE}"
+        "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_IMAGE}:latest",
+        "${LOCATION}-docker.pkg.dev/${PROJECT_ID}/vecoli/${_IMAGE}:${_GIT_HASH}"
     ]
 }

--- a/runscripts/container/interactive.sh
+++ b/runscripts/container/interactive.sh
@@ -167,6 +167,7 @@ else
     docker container run -it \
       --env UV_PROJECT_ENVIRONMENT=/vEcoli/.venv \
       --env UV_COMPILE_BYTECODE=0 \
+      -v $(pwd):$(pwd) --workdir $(pwd) \
       ${BIND_STR} ${IMAGE_NAME} \
       bash -c "uv sync --frozen && exec bash"
   else

--- a/runscripts/container/interactive.sh
+++ b/runscripts/container/interactive.sh
@@ -40,7 +40,7 @@ OVERLAY_SIZE=1024
 usage_str="Usage: interactive.sh [-i IMAGE_NAME] [-d] [-a] [-s OVERLAY_SIZE] [-l] [-b BUCKET] [-p PATH]\n\
 Options:\n\
     -i: Path to image to run if -a or -l are passed, otherwise name of Docker \
-image inside vecoli Artifact Repository; defaults to \"$IMAGE_NAME\".\n\
+image inside vecoli Artifact Registry; defaults to \"$IMAGE_NAME\".\n\
     -d: Create editable install of current directory in container virtual environment; \
 useful for making and testing code changes that, unlike changes to
 the code in the container at /vEcoli, are persistent and work with git.\n\
@@ -141,7 +141,7 @@ else
     # Non-local Docker images are pulled from Artifact Registry
     PROJECT=$(gcloud config get project)
     REGION=$(gcloud config get compute/region)
-    IMAGE_NAME="${REGION}-docker.pkg.dev/${PROJECT}/vecoli/${IMAGE_NAME}"
+    IMAGE_NAME="--pull=always ${REGION}-docker.pkg.dev/${PROJECT}/vecoli/${IMAGE_NAME}"
   fi
   echo "=== Launching Docker container from ${IMAGE_NAME} ==="
 


### PR DESCRIPTION
I forgot to actually set up build caching and add the necessary options for development containers on Google Cloud, as described in #296.

Setting up caching required some finesse because the [Google Cloud Build documentation](https://cloud.google.com/build/docs/optimize-builds/speeding-up-builds) is woefully out of date and, as it turns out, so is their Docker image. I had to change to the official Docker image and add a `--cache-to` argument in addition to the documented `--cache-from`, whose syntax is also different than described. For the record, none of the LLMs in Copilot were of any help in figuring this out.

Also, I added a flag to always pull from Artifact Registry before running to make sure we are using the latest version of an image. Finally, images will now be tagged with the Git hash they were built from for convenience.