### PR TITLE
Minor fixes

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -18,6 +18,6 @@ jobs:
           enable-cache: true
           version: "0.6.10"
       - name: Audit dependencies
-        run:
-          uv export --all-extras --format requirements-txt --no-emit-project > requirements.txt && \
-          uv tool run pip-audit -r requirements.txt --disable-pip --fix
+        run: |
+          uv export --all-extras --format requirements-txt --no-emit-project > requirements.txt
+          uvx pip-audit -r requirements.txt --disable-pip --fix

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -6,6 +6,14 @@ permissions:
 on:
   schedule:
     - cron: '00 00 * * *'
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -20,4 +28,4 @@ jobs:
       - name: Audit dependencies
         run: |
           uv export --all-extras --format requirements-txt --no-emit-project > requirements.txt
-          uvx pip-audit -r requirements.txt --disable-pip --fix
+          uvx pip-audit -r requirements.txt --disable-pip --fix -v

--- a/doc/experiments.rst
+++ b/doc/experiments.rst
@@ -386,6 +386,9 @@ Output
 If ``emitter`` was set to ``parquet``, then folders containing the simulation output are
 created as described in :ref:`parquet_emitter`.
 
+.. warning::
+    See :ref:`special_float_values` for an important caveat involving NaN/infinity.
+
 If ``division`` is set to True, :py:mod:`~ecoli.experiments.ecoli_master_sim` will
 save the initial states of the two daughter cells resulting from cell division
 in ``daughter_outdir`` as JSON files. These files can be moved to the ``data``

--- a/doc/output.rst
+++ b/doc/output.rst
@@ -316,6 +316,35 @@ for common query patterns. These include:
 - :py:func:`~ecoli.analysis.multivariant.new_gene_translation_efficiency_heatmaps.avg_1d_array_over_scalar_sql`
 - :py:func:`~ecoli.analysis.multivariant.new_gene_translation_efficiency_heatmaps.avg_sum_1d_array_over_scalar_sql`
 
+.. _special_float_values:
+
+Special Float Values
+====================
+
+The Parquet emitter uses ``orjson`` to convert simulation output data to an intermediate JSON
+format that is then written to Parquet.  Because special float values like NaN/infinity are
+not included in the JSON specification, ``orjson`` converts them to null. As such, processes
+**MUST** be written so that these values do not appear under normal circumstances.
+
+If you anticipate that these values may appear when something has gone wrong, note
+that DuckDB, the library used to read Parquet data, ignores null values by default in
+aggregation functions like ``sum`` and ``avg``. To make these aggregations return null if
+any input values are null, use the following syntax (example for ``sum``)::
+
+  SELECT
+    CASE
+      -- If any values in column are null, return null
+      WHEN bool_or(column_name is NULL) THEN NULL
+      -- Otherwise, perform the aggregation as normal
+      ELSE SUM(column_name)
+    END AS safe_sum
+  FROM your_table;
+
+For more advanced users who require these values for a one-off test, we have made a
+`branch of orjson <https://github.com/CovertLab/orjson/tree/updated-infnan>`_ that is
+patched to support these values. It is not actively maintained, and changes that require
+this patched package will not be merged into the main vEcoli codebase.
+
 ---------------------
 Other Workflow Output
 ---------------------

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -575,6 +575,9 @@ is a list workflow behaviors enabled in our model to handle unexpected errors.
 Output
 ------
 
+.. warning::
+  See :ref:`special_float_values` for an important caveat involving NaN/infinity.
+
 A completed workflow will have the following directory structure underneath
 the output directory specified via ``out_dir`` or ``out_uri`` under the
 ``emitter_arg`` option in the configuration JSON (see :ref:`json_config`):

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -372,6 +372,7 @@ def check_job_state(job_id, timeout_seconds=3600, sleep_interval=30):
 def forward_sbatch_output(
     batch_script: str,
     output_log: str,
+    timeout_seconds: int = 3600,
 ):
     """
     Submit a SLURM job that is configured to pipe its output to a log file.
@@ -434,7 +435,7 @@ def forward_sbatch_output(
         time.sleep(30)
 
     # Final check of job success
-    if not check_job_state(job_id):
+    if not check_job_state(job_id, timeout_seconds):
         sys.exit(1)
 
 
@@ -677,7 +678,7 @@ nextflow -C {config_path} run {workflow_path} -profile {nf_profile} \
         )
         # Make stdout of workflow viewable in Jenkins
         if sherlock_config.get("jenkins", False):
-            forward_sbatch_output(batch_script, nf_slurm_output)
+            forward_sbatch_output(batch_script, nf_slurm_output, 3600 * 24)
         else:
             subprocess.run(["sbatch", batch_script], check=True)
     shutil.rmtree(local_outdir)


### PR DESCRIPTION
- More robust logic for checking the status of a job on SLURM
- Fix the pip-audit GitHub Action once and for all (also run on every PR and change to `master`)
- Document an important caveat involving nan/inf values
- Set a hard 24 hour limit on Jenkins tests
  - Current Jenkins jobs all set custom timeouts lower than this hard limit (see Jenkinsfiles at `runscripts/jenkins/Jenkinsfile`)