### PR TITLE
Fix datatype bug to allow parquet file saving with ppGpp growth-rate control turned off

### DIFF
--- a/ecoli/processes/polypeptide_elongation.py
+++ b/ecoli/processes/polypeptide_elongation.py
@@ -790,7 +790,9 @@ class BaseElongationModel(object):
     ):
         # Update counts of amino acids and water to reflect polymerization
         # reactions
-        net_charged = np.zeros(len(self.parameters["uncharged_trna_names"]))
+        net_charged = np.zeros(
+            len(self.parameters["uncharged_trna_names"]), dtype=np.int64
+        )
         return (
             net_charged,
             {},


### PR DESCRIPTION
This PR is a small bug fix. Previously, if running with ppGpp growth-rate control turned off (e.g. if running using the MetabolismReduxClassic process), the BaseElongationModel in the process PolypeptideElongation is used. Then there was a bug for a listener that should be an int but is set to a double, resulting in parquet output files not being saved and returning an error at _finalize in parquet_emitter.py. Now the bug is fixed and the parquet files can be saved (branch being called fix-units-bug is a misnomer, sorry!).