### PR TITLE
Add some analyses and tweak new gene module

### DIFF
--- a/ecoli/analysis/multiseed/protein_counts_validation.py
+++ b/ecoli/analysis/multiseed/protein_counts_validation.py
@@ -1,0 +1,126 @@
+import os
+import pickle
+from typing import Any
+
+from duckdb import DuckDBPyConnection
+import numpy as np
+import polars as pl
+from scipy.stats import pearsonr
+import altair as alt
+
+from ecoli.library.parquet_emitter import (
+    open_arbitrary_sim_data,
+    ndlist_to_ndarray,
+    read_stacked_columns,
+)
+from wholecell.utils.protein_counts import get_simulated_validation_counts
+
+
+def plot(
+    params: dict[str, Any],
+    conn: DuckDBPyConnection,
+    history_sql: str,
+    config_sql: str,
+    success_sql: str,
+    sim_data_paths: dict[str, dict[int, str]],
+    validation_data_paths: list[str],
+    outdir: str,
+    variant_metadata: dict[str, dict[int, Any]],
+    variant_names: dict[str, str],
+):
+    with open_arbitrary_sim_data(sim_data_paths) as f:
+        sim_data = pickle.load(f)
+    with open(validation_data_paths[0], "rb") as f:
+        validation_data = pickle.load(f)
+
+    subquery = read_stacked_columns(
+        history_sql, ["listeners__monomer_counts"], order_results=False
+    )
+    monomer_counts = conn.sql(f"""
+        WITH unnested_counts AS (
+            SELECT unnest(listeners__monomer_counts) AS counts,
+                generate_subscripts(listeners__monomer_counts, 1) AS idx,
+                experiment_id, variant, lineage_seed, generation, agent_id
+            FROM ({subquery})
+        ),
+        avg_counts AS (
+            SELECT avg(counts) AS avgCounts,
+                experiment_id, variant, lineage_seed,
+                generation, agent_id, idx
+            FROM unnested_counts
+            GROUP BY experiment_id, variant, lineage_seed,
+                generation, agent_id, idx
+        )
+        SELECT list(avgCounts ORDER BY idx) AS avgCounts
+        FROM avg_counts
+        GROUP BY experiment_id, variant, lineage_seed, generation, agent_id
+        """).arrow()
+    monomer_counts = ndlist_to_ndarray(monomer_counts["avgCounts"])
+
+    sim_monomer_ids = sim_data.process.translation.monomer_data["id"]
+    wisniewski_ids = validation_data.protein.wisniewski2014Data["monomerId"]
+    schmidt_ids = validation_data.protein.schmidt2015Data["monomerId"]
+    wisniewski_counts = validation_data.protein.wisniewski2014Data["avgCounts"]
+    schmidt_counts = validation_data.protein.schmidt2015Data["glucoseCounts"]
+    sim_wisniewski_counts, val_wisniewski_counts = get_simulated_validation_counts(
+        wisniewski_counts, monomer_counts, wisniewski_ids, sim_monomer_ids
+    )
+    sim_schmidt_counts, val_schmidt_counts = get_simulated_validation_counts(
+        schmidt_counts, monomer_counts, schmidt_ids, sim_monomer_ids
+    )
+
+    schmidt_chart = (
+        alt.Chart(
+            pl.DataFrame(
+                {
+                    "schmidt": np.log10(val_schmidt_counts + 1),
+                    "sim": np.log10(sim_schmidt_counts + 1),
+                }
+            )
+        )
+        .mark_point()
+        .encode(
+            x=alt.X("schmidt", title="log10(Schmidt 2015 Counts + 1)"),
+            y=alt.Y("sim", title="log10(Simulation Average Counts + 1)"),
+        )
+        .properties(
+            title="Pearson r: %0.2f"
+            % pearsonr(
+                np.log10(sim_schmidt_counts + 1), np.log10(val_schmidt_counts + 1)
+            )[0]
+        )
+    )
+    wisniewski_chart = (
+        alt.Chart(
+            pl.DataFrame(
+                {
+                    "wisniewski": np.log10(val_wisniewski_counts + 1),
+                    "sim": np.log10(sim_wisniewski_counts + 1),
+                }
+            )
+        )
+        .mark_point()
+        .encode(
+            x=alt.X("wisniewski", title="log10(Wisniewski 2014 Counts + 1)"),
+            y=alt.Y("sim", title="log10(Simulation Average Counts + 1)"),
+        )
+        .properties(
+            title="Pearson r: %0.2f"
+            % pearsonr(
+                np.log10(sim_wisniewski_counts + 1), np.log10(val_wisniewski_counts + 1)
+            )[0]
+        )
+    )
+    max_val = max(
+        np.log10(val_schmidt_counts + 1).max(),
+        np.log10(val_wisniewski_counts + 1).max(),
+        np.log10(sim_schmidt_counts + 1).max(),
+        np.log10(sim_wisniewski_counts + 1).max(),
+    )
+    parity = (
+        alt.Chart(pl.DataFrame({"x": np.arange(max_val)}))
+        .mark_line()
+        .encode(x="x", y="x", color=alt.value("red"), strokeDash=alt.value([5, 5]))
+    )
+    chart = (schmidt_chart + parity) | (wisniewski_chart + parity)
+    chart.save(os.path.join(outdir, "protein_counts_validation.html"))

--- a/ecoli/analysis/multiseed/ribosome_spacing.py
+++ b/ecoli/analysis/multiseed/ribosome_spacing.py
@@ -1,0 +1,127 @@
+import pickle
+from typing import Any
+
+from duckdb import DuckDBPyConnection
+import numpy as np
+import polars as pl
+
+from ecoli.library.parquet_emitter import (
+    open_arbitrary_sim_data,
+    read_stacked_columns,
+    get_field_metadata,
+    ndidx_to_duckdb_expr,
+)
+from wholecell.utils import units
+
+
+def plot(
+    params: dict[str, Any],
+    conn: DuckDBPyConnection,
+    history_sql: str,
+    config_sql: str,
+    success_sql: str,
+    sim_data_paths: dict[str, dict[int, str]],
+    validation_data_paths: list[str],
+    outdir: str,
+    variant_metadata: dict[str, dict[int, Any]],
+    variant_names: dict[str, str],
+):
+    with open_arbitrary_sim_data(sim_data_paths) as f:
+        sim_data = pickle.load(f)
+
+    # Map monomer IDs to cistron indices
+    monomer_data = sim_data.process.translation.monomer_data.struct_array
+    monomer_to_cistron_id = dict(zip(monomer_data["id"], monomer_data["cistron_id"]))
+    mrna_cistron_ids = get_field_metadata(
+        conn, config_sql, "listeners__rna_counts__mRNA_cistron_counts"
+    )
+    cistron_idx_dict = {rna: i for i, rna in enumerate(mrna_cistron_ids)}
+    monomer_ids = get_field_metadata(conn, config_sql, "listeners__monomer_counts")
+    cistron_idx_for_monomers = [
+        cistron_idx_dict[monomer_to_cistron_id[monomer_id]]
+        for monomer_id in monomer_ids
+    ]
+
+    monomer_counts_sql = read_stacked_columns(
+        history_sql,
+        [
+            "listeners__ribosome_data__ribosome_init_event_per_monomer AS init",
+            "listeners__rna_counts__mRNA_cistron_counts AS mrna_counts",
+        ],
+        order_results=False,
+    )
+
+    monomer_mrna_counts = ndidx_to_duckdb_expr(
+        "mrna_counts", [cistron_idx_for_monomers]
+    )
+
+    # Get aggregate ribosomes initiations per mRNA
+    inits_per_mrna = conn.sql(f"""
+        WITH extract_counts AS (
+            SELECT init, {monomer_mrna_counts},
+                experiment_id, variant, lineage_seed, generation, agent_id
+            FROM ({monomer_counts_sql})
+        ),
+        unnested AS (
+            SELECT unnest(init) AS init,
+                unnest(mrna_counts) AS mrna_counts,
+                generate_subscripts(init, 1) AS idx,
+                experiment_id, variant, lineage_seed, generation, agent_id
+            FROM extract_counts
+        ),
+        ratio AS (
+            SELECT 
+                CASE
+                    WHEN mrna_counts = 0 THEN 0
+                    ELSE init / mrna_counts
+                END AS inits_per_mrna, idx,
+                experiment_id, variant, lineage_seed, generation, agent_id
+            FROM unnested
+        )
+        SELECT idx, max(inits_per_mrna) AS max_inits,
+            avg(inits_per_mrna) AS avg_inits,
+            
+        FROM ratio
+        GROUP BY idx, 
+        ORDER BY avg_inits DESC
+    """).pl()
+
+    ribosome_footprint_size = (
+        sim_data.process.translation.active_ribosome_footprint_size.asNumber(units.nt)
+    )
+    nutrients = sim_data.conditions[sim_data.condition]["nutrients"]
+    ribosome_elongation_rate = (
+        sim_data.process.translation.ribosomeElongationRateDict[nutrients].asNumber(
+            units.aa / units.s
+        )
+        * 3
+    )
+
+    ribosome_spacing = pl.DataFrame(
+        [
+            pl.Series(monomer_ids)[inits_per_mrna["idx"] - 1].alias("Monomer ID"),
+            (ribosome_elongation_rate / inits_per_mrna["avg_inits"]).alias(
+                "Average Ribosome Spacing (nt)"
+            ),
+            (ribosome_elongation_rate / inits_per_mrna["max_inits"]).alias(
+                "Minimum Ribosome Spacing (nt)"
+            ),
+            pl.Series(np.full(len(inits_per_mrna), ribosome_footprint_size)).alias(
+                "Ribosome Footprint Size (nt)"
+            ),
+        ]
+    )
+
+    ribosome_spacing = ribosome_spacing.select(
+        ["Monomer ID"]
+        + [
+            pl.when(pl.col(col).is_infinite())
+            .then(None)
+            .otherwise(pl.col(col))
+            .alias(col)
+            for col in ribosome_spacing.columns
+            if col != "Monomer ID"
+        ]
+    )
+
+    ribosome_spacing.write_csv(f"{outdir}/ribosome_spacing.csv")

--- a/ecoli/analysis/multivariant/doubling_time_hist.py
+++ b/ecoli/analysis/multivariant/doubling_time_hist.py
@@ -1,0 +1,110 @@
+import altair as alt
+
+# noinspection PyUnresolvedReferences
+from duckdb import DuckDBPyConnection
+import polars as pl
+from typing import Any, cast
+
+from ecoli.library.parquet_emitter import read_stacked_columns, skip_n_gens
+
+
+def plot(
+    params: dict[str, Any],
+    conn: DuckDBPyConnection,
+    history_sql: str,
+    config_sql: str,
+    success_sql: str,
+    sim_data_dict: dict[str, dict[int, str]],
+    validation_data_paths: list[str],
+    outdir: str,
+    variant_metadata: dict[str, dict[int, Any]],
+    variant_names: dict[str, str],
+):
+    """
+    Histogram of doubling times with average marked.
+    """
+    import time
+
+    start_time = time.time()
+    doubling_time_sql = read_stacked_columns(
+        history_sql,
+        ["time"],
+        order_results=False,
+        success_sql=success_sql,
+    )
+    # Skip first 8 generations to avoid initialization bias
+    doubling_time_sql = skip_n_gens(doubling_time_sql, 8)
+    doubling_times = conn.sql(f"""
+        SET enable_profiling = 'query_tree_optimizer';
+        SELECT (max(time) - min(time)) / 60 AS 'Doubling Time (min)', experiment_id, variant, lineage_seed, generation, agent_id
+        FROM ({doubling_time_sql})
+        GROUP BY experiment_id, variant, lineage_seed, generation, agent_id
+    """).pl()
+    print(
+        f"{time.ctime()}: Finished calculating doubling times in {time.time() - start_time:.2f} seconds"
+    )
+    # Calculate the average doubling time
+    avg_doubling_time = doubling_times["Doubling Time (min)"].mean()
+    if avg_doubling_time is None:
+        raise ValueError("No doubling times found in the data.")
+    # Round for display
+    avg_doubling_time_rounded = round(cast(float, avg_doubling_time), 2)
+
+    # Create the base histogram - Define the main X-axis here
+    hist = (
+        alt.Chart(doubling_times)
+        .mark_bar()
+        .encode(
+            x=alt.X(
+                "Doubling Time (min)",
+                bin=alt.Bin(maxbins=40),
+                axis=alt.Axis(title="Doubling Time (min)", labelFlush=False),
+            ),  # Explicit title
+            y=alt.Y("count()", axis=alt.Axis(title="Frequency")),  # Nicer Y-axis title
+            tooltip=[
+                alt.Tooltip("Doubling Time (min)", bin=alt.Bin(maxbins=40)),
+                "count()",
+            ],
+        )
+    )
+
+    # Create a DataFrame for the rule and text
+    avg_df = pl.DataFrame({"avg": [avg_doubling_time]})
+
+    # Create the vertical rule for the average - Disable its X-axis labels/title
+    rule = (
+        alt.Chart(avg_df)
+        .mark_rule(color="red", strokeDash=[5, 5], size=2)
+        .encode(
+            x=alt.X("avg:Q"),
+            tooltip=[
+                alt.Tooltip("avg", title=f"Average: {avg_doubling_time_rounded} min")
+            ],
+        )
+    )
+
+    # Create the text label for the average line - Disable its X-axis labels/title
+    text = (
+        alt.Chart(avg_df)
+        .mark_text(align="left", baseline="middle", dx=7, dy=-20, color="red")
+        .encode(
+            x=alt.X("avg:Q"),
+            text=alt.value(f"{avg_doubling_time_rounded} min"),
+            tooltip=[
+                alt.Tooltip("avg", title=f"Average: {avg_doubling_time_rounded} min")
+            ],
+        )
+    )
+
+    # Combine the histogram, the rule, and the text label
+    # The final chart will use the axis definitions from the 'hist' layer
+    chart = hist + rule + text
+
+    # Add overall chart title
+    chart = chart.properties(title="Distribution of Doubling Times")
+
+    # Optional: Add interactivity if desired
+    chart = chart.interactive()
+
+    # Save the chart
+    chart.save(f"{outdir}/doubling_time_histogram.html")

--- a/ecoli/analysis/multivariant/doubling_time_line.py
+++ b/ecoli/analysis/multivariant/doubling_time_line.py
@@ -30,31 +30,31 @@ def plot(
         order_results=False,
     )
     doubling_times = conn.sql(f"""
-        SELECT (max(time) - min(time)) / 3600 AS 'Doubling Time (hrs)', experiment_id, variant, lineage_seed, generation, agent_id
+        SELECT (max(time) - min(time)) / 3600 AS 'Doubling Time (hr)', experiment_id, variant, lineage_seed, generation, agent_id
         FROM ({doubling_time_sql})
-        GROUP BY experiment_id, variant, Seed, Generation, agent_id
+        GROUP BY experiment_id, variant, lineage_seed, generation, agent_id
     """).pl()
     successful_sims = conn.sql(success_sql).pl()
-    doubling_times = doubling_times.join(
-        successful_sims,
-        how="semi",
-        on=["experiment_id", "variant", "lineage_seed", "generation", "agent_id"],
-    )
     death_times = doubling_times.join(
         successful_sims,
         how="anti",
-        on=["experiment_id", "variant", "lineage_seed", "generation", "agent_id"],
+        on=["experiment_id", "variant", "lineage_seed", "agent_id"],
+    )
+    doubling_times = doubling_times.join(
+        successful_sims,
+        how="semi",
+        on=["experiment_id", "variant", "lineage_seed", "agent_id"],
     )
 
-    selection = alt.selection_point(fields=["Seed"], bind="legend")
+    selection = alt.selection_point(fields=["lineage_seed"], bind="legend")
     chart = (
         alt.Chart(doubling_times)
         .mark_line()
         .encode(
-            x="Generation",
+            x="generation",
             y="Doubling Time (hr)",
-            color=alt.Color("Seed", type="nominal"),
-            tooltip=["Doubling Time (hr)", "Seed"],
+            color=alt.Color("lineage_seed", type="nominal"),
+            tooltip=["Doubling Time (hr)", "lineage_seed"],
             opacity=alt.when(selection).then(alt.value(1)).otherwise(alt.value(0.2)),
         )
         .add_params(selection)
@@ -64,21 +64,21 @@ def plot(
         alt.Chart(death_times)
         .mark_point(shape="cross")
         .encode(
-            x="Generation",
+            x="generation",
             y="Doubling Time (hr)",
-            color=alt.Color("Seed", type="nominal"),
+            color=alt.Color("lineage_seed", type="nominal"),
             opacity=alt.when(selection).then(alt.value(1)).otherwise(alt.value(0.2)),
-            tooltip=["Doubling Time (hr)", "Seed"],
+            tooltip=["Doubling Time (hr)", "lineage_seed"],
         )
     )
     exp_avg = alt.Chart().mark_rule(strokeDash=[2, 2]).encode(y=alt.datum(1 / 0.47))
-    sim_avg_df = doubling_times.group_by("experiment_id", "variant", "Generation").agg(
+    sim_avg_df = doubling_times.group_by("experiment_id", "variant", "generation").agg(
         pl.mean("Doubling Time (hr)")
     )
     sim_avg = (
         alt.Chart(sim_avg_df)
         .mark_line(strokeDash=[2, 2])
-        .encode(x="Generation", y="Doubling Time (hr)", tooltip=["Doubling Time (hr)"])
+        .encode(x="generation", y="Doubling Time (hr)", tooltip=["Doubling Time (hr)"])
     )
     chart = chart + exp_avg + sim_avg + death_points
     chart.save(f"{outdir}/doubling_time.html")

--- a/ecoli/composites/ecoli_configs/default.json
+++ b/ecoli/composites/ecoli_configs/default.json
@@ -51,6 +51,10 @@
         "variable_elongation_translation": false
     },
 
+    "analysis_options": {
+        "cpus": 1
+    },
+
     "gcloud": null,
 
     "agent_id": "0",

--- a/ecoli/composites/ecoli_master_tests.py
+++ b/ecoli/composites/ecoli_master_tests.py
@@ -93,7 +93,7 @@ def test_division(agent_id="0", total_time=4):
     # this is not exact because the mother grew slightly in the timestep
     # after its last emit but before being split into two daughter cells
     assert np.allclose(
-        mother_bulk, np.array(daughter_bulk[0]) + np.array(daughter_bulk[1]), atol=51
+        mother_bulk, np.array(daughter_bulk[0]) + np.array(daughter_bulk[1]), atol=60
     )
 
     # compare the counts of unique molecules between the mother and daughters

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -548,9 +548,8 @@ def read_stacked_columns(
             If provided, will be used to filter out unsuccessful sims.
     """
     id_cols = "experiment_id, variant, lineage_seed, generation, agent_id, time"
-    columns.append(id_cols)
     columns = ", ".join(columns)
-    sql_query = f"SELECT {columns} FROM ({history_sql})"
+    sql_query = f"SELECT {columns}, {id_cols} FROM ({history_sql})"
     # Use a semi join to filter out unsuccessful sims
     if success_sql is not None:
         sql_query = f"""
@@ -563,8 +562,8 @@ def read_stacked_columns(
         sql_query = f"""
             SELECT * FROM ({sql_query})
             ANTI JOIN (
-                SELECT (experiment_id, variant, lineage_seed, generation,
-                    agent_id, MIN(time))
+                SELECT experiment_id, variant, lineage_seed, generation,
+                    agent_id, MIN(time) AS time
                 FROM ({history_sql.replace("COLNAMEHERE", "time")})
                 GROUP BY experiment_id, variant, lineage_seed, generation,
                     agent_id

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -247,7 +247,9 @@ def ndarray_to_ndlist(arr: np.ndarray) -> pa.FixedSizeListArray:
     return nested_array
 
 
-def ndidx_to_duckdb_expr(name: str, idx: list[int | list[int | bool] | str]) -> str:
+def ndidx_to_duckdb_expr(
+    name: str, idx: list[int | list[int] | list[bool] | str]
+) -> str:
     """
     Returns a DuckDB expression for a column equivalent to converting each row
     of ``name`` into an ndarray ``name_arr`` (:py:func:`~.ndlist_to_ndarray`)
@@ -303,8 +305,10 @@ def ndidx_to_duckdb_expr(name: str, idx: list[int | list[int | bool] | str]) -> 
                 raise TypeError("Indices must be integers or boolean masks.")
         elif indices == ":":
             select_expr = f"list_transform(x_{i + 1}, x_{i} -> {select_expr})"
-        elif isinstance(first_idx, int):
-            select_expr = f"list_transform(x_{i + 1}[{cast(int, indices) + 1}], x_{i} -> {select_expr})"
+        elif isinstance(indices, int):
+            select_expr = (
+                f"list_transform(x_{i + 1}[{int(indices) + 1}], x_{i} -> {select_expr})"
+            )
         else:
             raise TypeError("All indices must be lists, ints, or ':'.")
     select_expr = select_expr.replace(f"x_{i + 1}", name)

--- a/ecoli/processes/polypeptide_initiation.py
+++ b/ecoli/processes/polypeptide_initiation.py
@@ -87,9 +87,10 @@ class PolypeptideInitiation(PartitionedProcess):
         ]
         self.tu_ids = self.parameters["tu_ids"]
         self.n_TUs = len(self.tu_ids)
-        self.active_ribosome_footprint_size = self.parameters[
-            "active_ribosome_footprint_size"
-        ]
+        # Convert ribosome footprint size from nucleotides to amino acids
+        self.active_ribosome_footprint_size = (
+            self.parameters["active_ribosome_footprint_size"] / 3
+        )
 
         # Get mapping from cistrons to protein monomers and TUs
         self.cistron_to_monomer_mapping = self.parameters["cistron_to_monomer_mapping"]

--- a/ecoli/variants/new_gene_internal_shift.py
+++ b/ecoli/variants/new_gene_internal_shift.py
@@ -139,15 +139,14 @@ def apply_variant(
     sim_data.internal_shift_dict = {}  # type: ignore[attr-defined]
 
     # Add the new gene induction to the internal_shift instructions
-    if params["induction_gen"] != -1:
-        sim_data.internal_shift_dict[params["induction_gen"]] = (  # type: ignore[attr-defined]
-            modify_new_gene_exp_trl,
-            (params["exp_trl_eff"]["exp"], params["exp_trl_eff"]["trl_eff"]),
-        )
-    if params["knockout_gen"] != -1:
-        assert params["knockout_gen"] > params["induction_gen"], (
-            "New genes are knocked out by default, so induction should happen"
-            " before knockout."
+    induction_gen = params.get("induction_gen", 1)
+    sim_data.internal_shift_dict[induction_gen] = (  # type: ignore[attr-defined]
+        modify_new_gene_exp_trl,
+        (params["exp_trl_eff"]["exp"], params["exp_trl_eff"]["trl_eff"]),
+    )
+    if "knockout_gen" in params:
+        assert params["knockout_gen"] > induction_gen, (
+            "knockout_gen must be after induction_gen"
         )
         sim_data.internal_shift_dict[params["knockout_gen"]] = (  # type: ignore[attr-defined]
             modify_new_gene_exp_trl,

--- a/reconstruction/ecoli/flat/adjustments/rna_expression_adjustments.tsv
+++ b/reconstruction/ecoli/flat/adjustments/rna_expression_adjustments.tsv
@@ -7,6 +7,6 @@
 "EG10236_RNA"	10		"fit_sim_data_1.py"	"dnaB, replicative DNA helicase; This RNA is fit for the sims to produce enough DNAPs for timely replication in anaerobic condition"
 "EG10238_RNA"	10		"fit_sim_data_1.py"	"dnaE, DNA polymerase III subunit alpha; This RNA is fit for the sims to produce enough DNAPs for timely replication"
 "EG11673_RNA"	10		"fit_sim_data_1.py"	"folB, dihydroneopterin aldolase; needed for growth (METHYLENE-THF) in acetate condition"
-"EG10808_RNA"	4		"fit_sim_data_1.py"	"pyrE, orotate phosphoribosyltransferase; Needed for UTP synthesis, transcriptional regulation by UTP is not included in the model"
+"EG10808_RNA"	10		"fit_sim_data_1.py"	"pyrE, orotate phosphoribosyltransferase; Needed for UTP synthesis, transcriptional regulation by UTP is not included in the model"
 "EG10581_RNA"	10			"metA, homoserine O-succinyltransferase; Met synthesis enzyme with low protein expression on aa_synthesis_enzymes parca analysis plot"
 "EG10091_RNA"	10			"asnA, asparagine synthetase A; Asn synthesis enzyme with low protein expression on aa_synthesis_enzymes parca analysis plot"

--- a/reconstruction/ecoli/flat/adjustments/translation_efficiencies_adjustments.tsv
+++ b/reconstruction/ecoli/flat/adjustments/translation_efficiencies_adjustments.tsv
@@ -24,3 +24,4 @@
 "NUON-MONOMER[m]"	5		"fit_sim_data_1.py"	"Main NADH:quinone oxidoreductase. Better alignment with ribosome profiling"
 "HOMOCYSMET-MONOMER[c]"	2		"fit_sim_data_1.py"	"Main methionine synthase when there's no B12. Better alignment with ribosome profiling"
 "PGMI-MONOMER[c]"	0.25		"fit_sim_data_1.py"	"Better alignment with ribosome profiling"
+"EG10242-MONOMER[c]"	3		"fit_sim_data_1.py"	"dnaN, important for mechanistic replisome and better match experimental counts"

--- a/reconstruction/ecoli/flat/new_gene_data/gfp/genes.tsv
+++ b/reconstruction/ecoli/flat/new_gene_data/gfp/genes.tsv
@@ -1,2 +1,2 @@
 "id"	"symbol"	"synonyms"	"left_end_pos"	"right_end_pos"	"direction"	"rna_ids"
-"NG001"	"gfp"	["gfp"]	0	716	"+"	["NG001_RNA"]
+"NG001"	"gfp"	["gfp"]	1	717	"+"	["NG001_RNA"]

--- a/reconstruction/ecoli/knowledge_base_raw.py
+++ b/reconstruction/ecoli/knowledge_base_raw.py
@@ -343,10 +343,7 @@ class KnowledgeBaseEcoli(object):
                 + insertion_sequence
                 + self.genome_sequence[insert_pos:]
             )
-            assert (
-                self.genome_sequence[insert_pos : (insert_end + 1)]
-                == insertion_sequence
-            )
+            assert self.genome_sequence[insert_pos:insert_end] == insertion_sequence
 
             self.added_data = self.new_gene_added_data
             self._join_data()
@@ -648,7 +645,7 @@ class KnowledgeBaseEcoli(object):
             ), "gaps in new gene insertions are not supported at this time"
 
         insert_end = new_genes_data[-1]["right_end_pos"] + insert_pos
-        insert_len = insert_end - insert_pos + 1
+        insert_len = insert_end - insert_pos
 
         # Update global positions of original genes
         self._update_global_coordinates(genes_data, insert_pos, insert_len)
@@ -686,8 +683,8 @@ class KnowledgeBaseEcoli(object):
 
         insertion_seq = Seq.Seq("")
         new_genes_data = sorted(new_genes_data, key=lambda d: d["left_end_pos"])
-        assert new_genes_data[0]["left_end_pos"] == 0, (
-            "first gene in new sequence must start at relative coordinate 0"
+        assert new_genes_data[0]["left_end_pos"] == 1, (
+            "first gene in new sequence must start at relative coordinate 1"
         )
 
         for gene in new_genes_data:

--- a/runscripts/analysis.py
+++ b/runscripts/analysis.py
@@ -145,7 +145,6 @@ def main():
         "--cpus",
         "-n",
         type=int,
-        default=1,
         help="Number of CPUs to use for DuckDB and PyArrow.",
     )
     parser.add_argument(

--- a/runscripts/create_variants.py
+++ b/runscripts/create_variants.py
@@ -62,6 +62,9 @@ def parse_variants(
     # Extract operation if more than one parameter
     operation = None
     if len(variant_config) > 1:
+        assert "op" in variant_config, (
+            "Variant has more than 1 parameter but no op key defined."
+        )
         operation = variant_config.pop("op")
     elif "op" in variant_config:
         raise TypeError(

--- a/runscripts/jenkins/configs/ecoli-anaerobic.json
+++ b/runscripts/jenkins/configs/ecoli-anaerobic.json
@@ -24,7 +24,7 @@
     "analysis_options": {
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
-        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
+        "multivariant": {"doubling_time_hist": {"skip_n_gens": 0}, "doubling_time_line": {}}
     },
     "variants": {
         "condition": {"condition": {"value": ["no_oxygen"]}}

--- a/runscripts/jenkins/configs/ecoli-anaerobic.json
+++ b/runscripts/jenkins/configs/ecoli-anaerobic.json
@@ -22,7 +22,9 @@
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {
-        "single": {"mass_fraction_summary": {}}
+        "single": {"mass_fraction_summary": {}},
+        "multiseed": {"protein_counts_validation": {}},
+        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
     },
     "variants": {
         "condition": {"condition": {"value": ["no_oxygen"]}}

--- a/runscripts/jenkins/configs/ecoli-glucose-minimal.json
+++ b/runscripts/jenkins/configs/ecoli-glucose-minimal.json
@@ -11,7 +11,7 @@
     "analysis_options": {
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
-        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
+        "multivariant": {"doubling_time_hist": {"skip_n_gens": 0}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-glucose-minimal.json
+++ b/runscripts/jenkins/configs/ecoli-glucose-minimal.json
@@ -9,7 +9,9 @@
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {
-        "single": {"mass_fraction_summary": {}}
+        "single": {"mass_fraction_summary": {}},
+        "multiseed": {"protein_counts_validation": {}},
+        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -16,7 +16,7 @@
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
         "multivariant": {
-            "doubling_time_hist": {},
+            "doubling_time_hist": {"skip_n_gens": 0},
             "doubling_time_line": {},
             "new_gene_translation_efficiency_heatmaps": {
                 "count_index": 4,
@@ -30,7 +30,6 @@
         "new_gene_internal_shift": {
             "condition": {"value": ["basal"]},
             "induction_gen": {"value": [1]},
-            "knockout_gen": {"value": [-1]},
             "exp_trl_eff": {
                 "nested": {
                     "exp": {

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -15,7 +15,15 @@
     "analysis_options": {
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
-        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
+        "multivariant": {
+            "doubling_time_hist": {},
+            "doubling_time_line": {},
+            "new_gene_translation_efficiency_heatmaps": {
+                "count_index": 4,
+                "min_cell_index": 1,
+                "max_cell_index": 5
+            }
+        }
     },
     "skip_baseline": true,
     "variants": {

--- a/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
+++ b/runscripts/jenkins/configs/ecoli-new-gene-gfp.json
@@ -13,7 +13,9 @@
         "cpus": 4
     },
     "analysis_options": {
-        "single": {"mass_fraction_summary": {}}
+        "single": {"mass_fraction_summary": {}},
+        "multiseed": {"protein_counts_validation": {}},
+        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
     },
     "skip_baseline": true,
     "variants": {

--- a/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
+++ b/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
@@ -18,7 +18,9 @@
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {
-        "single": {"mass_fraction_summary": {}}
+        "single": {"mass_fraction_summary": {}},
+        "multiseed": {"protein_counts_validation": {}},
+        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
+++ b/runscripts/jenkins/configs/ecoli-no-growth-rate-control.json
@@ -20,7 +20,7 @@
     "analysis_options": {
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
-        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
+        "multivariant": {"doubling_time_hist": {"skip_n_gens": 0}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-no-operons.json
+++ b/runscripts/jenkins/configs/ecoli-no-operons.json
@@ -15,7 +15,7 @@
     "analysis_options": {
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
-        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
+        "multivariant": {"doubling_time_hist": {"skip_n_gens": 0}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-no-operons.json
+++ b/runscripts/jenkins/configs/ecoli-no-operons.json
@@ -13,7 +13,9 @@
         "cpus": 4
     },
     "analysis_options": {
-        "single": {"mass_fraction_summary": {}}
+        "single": {"mass_fraction_summary": {}},
+        "multiseed": {"protein_counts_validation": {}},
+        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-superhelical-density.json
+++ b/runscripts/jenkins/configs/ecoli-superhelical-density.json
@@ -10,7 +10,9 @@
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {
-        "single": {"mass_fraction_summary": {}}
+        "single": {"mass_fraction_summary": {}},
+        "multiseed": {"protein_counts_validation": {}},
+        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-superhelical-density.json
+++ b/runscripts/jenkins/configs/ecoli-superhelical-density.json
@@ -12,7 +12,7 @@
     "analysis_options": {
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
-        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
+        "multivariant": {"doubling_time_hist": {"skip_n_gens": 0}, "doubling_time_line": {}}
     },
     "sherlock": {
         "container_image": "container-image",

--- a/runscripts/jenkins/configs/ecoli-with-aa.json
+++ b/runscripts/jenkins/configs/ecoli-with-aa.json
@@ -10,7 +10,9 @@
         "out_dir": "/scratch/groups/mcovert/vecoli"
     },
     "analysis_options": {
-        "single": {"mass_fraction_summary": {}}
+        "single": {"mass_fraction_summary": {}},
+        "multiseed": {"protein_counts_validation": {}},
+        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
     },
     "skip_baseline": true,
     "variants": {

--- a/runscripts/jenkins/configs/ecoli-with-aa.json
+++ b/runscripts/jenkins/configs/ecoli-with-aa.json
@@ -12,7 +12,7 @@
     "analysis_options": {
         "single": {"mass_fraction_summary": {}},
         "multiseed": {"protein_counts_validation": {}},
-        "multivariant": {"doubling_time_hist": {}, "doubling_time_line": {}}
+        "multivariant": {"doubling_time_hist": {"skip_n_gens": 0}, "doubling_time_line": {}}
     },
     "skip_baseline": true,
     "variants": {

--- a/wholecell/tests/utils/profile_polymerize.py
+++ b/wholecell/tests/utils/profile_polymerize.py
@@ -67,9 +67,6 @@ def setup_profiler():
     )
 
 
-setup_profiler()
-
-
 def _setupRealExample():
     # Test data pulled from an actual sim at an early time point.
     monomerLimits = np.array(
@@ -226,4 +223,5 @@ def _fullProfile():
 
 
 if __name__ == "__main__":
+    setup_profiler()
     _fullProfile()


### PR DESCRIPTION
New analyses
- Protein counts validation
- Doubling time histogram
- Ribosome spacing on mRNAs

Analyses updated/fixed
- Doubling time line
- New gene heat maps

Modeling changes
- Make new gene coordinates 1-indexed
- Use same units (codons or amino acids) for ribosome footprint and ribosome elongation rate

Bug fixes
- Fix anti join in `read_stacked_columns` (bug I introduced in f823d77)
- Do not mutate input columns to `read_stacked_column` (bug I introduced in f823d77)
- Allow users to set # CPUs in JSON for analyses
- In DuckDB helper functions, set row to 0 if dividing by 0 (`stddev` cannot handle `nan`/`inf`)
- Correctly handle integer indices in `ndidx_to_duckdb_expr`
- Move polymerize profiling monkey-patch under `if __name__ == '__main__'` to avoid running in pytest