### PR TITLE
Simplify SLURM job output forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ This will run the following basic simulation workflow:
 3. [Analyze simulation output](runscripts/analysis.py) by creating a
     [mass fraction plot](ecoli/analysis/single/mass_fraction_summary.py).
 
-## Next Steps
-Review the online [user guide](https://covertlab.github.io/vEcoli/) to learn how
-to configure and run your own simulation workflows.
+## Documentation
+The documentation is located at [https://covertlab.github.io/vEcoli/](https://covertlab.github.io/vEcoli/)
+and contains more information about the model architecture, output,
+and workflow configuration.
 
-If you encounter a problem that you cannot solve after searching the user guide
-(also linked in the repository sidebar), feel free to create a GitHub issue, and we will
+If you encounter an issue not addressed by the docs, feel free to create a GitHub issue, and we will
 get back to you as soon as we can.

--- a/doc/hpc.rst
+++ b/doc/hpc.rst
@@ -314,14 +314,7 @@ If not, you may run into errors when running workflows because
 Apptainer containers are read-only. You may be able to resolve this by
 adding ``--writeable-tmpfs`` to ``containerOptions`` for the ``sherlock``
 and ``sherlock-hq`` profiles in ``runscripts/nextflow/config.template``.
-
-If this does not work, Nextflow allows users to define ``beforeScript`` and
-``afterScript`` directives for each process that we can potentially use to create
-and clean up Apptainer overlay files. Then, the ``containerOptions``
-directive can be modified to start containers with these overlays. However,
-the simplest solution is likely to set up vEcoli as if Apptainer was not
-available (see below). Note that if Apptainer is not configured to automount
-filesystems, you will need to manually specify paths to mount when debugging
+Additionally, you will need to manually specify paths to mount when debugging
 with interactive containers (see :ref:`sherlock-interactive`). This can be done
 using the ``-p`` argument for ``runscripts/container/interactive.sh``.
 
@@ -356,7 +349,9 @@ If your HPC cluster uses a different scheduler, refer to the Nextflow
 for more information on configuring the right executor. Beyond changing queue
 names as described above, this could be as simple as modifying the ``executor``
 directives for the ``sherlock`` and ``sherlock_hq`` profiles in
-``runscripts/nextflow/config.template``.
+``runscripts/nextflow/config.template``. Additionally, you will need to
+replace the SLURM submission directives in :py:func:`runscripts.workflow.main`
+with equivalent directives for your scheduler.
 
 
 .. _hyperqueue:

--- a/doc/output.rst
+++ b/doc/output.rst
@@ -174,13 +174,6 @@ null values or nested types containing null values (e.g. empty list). For these 
 all values except the null entries must be the same type (e.g. column with lists
 of integers where some entries are empty lists).
 
-Currently, the Parquet emitter does not support saving data from stores that are
-dynamically added or removed over the course of a simulation or workflow. This means
-that all cells in a workflow must emit a consistent store hierarchy that flattens to
-a dictionary with the same double-underscore concatenated keys (resulting Parquet
-files all have the same columns). This limitation may be relaxed in the future via
-an optional flag that will come with an unknown performance penalty.
-
 The Parquet emitter saves the serialized tabular data to two Hive-partitioned
 directories in the output folder (``out_dir`` or ``out_uri`` option under
 ``emitter_arg`` in :ref:`json_config`):

--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -26,7 +26,7 @@ From: ghcr.io/astral-sh/uv@sha256:2597ffa44de9d160ca9ee2e1073728e6492af57b9abba5
 %post
     apt-get update && apt-get install -y gcc procps
     cd /vEcoli
-    UV_COMPILE_BYTECODE=1 uv sync --frozen
+    UV_CACHE_DIR="/vEcoli/.uv_cache" UV_COMPILE_BYTECODE=1 uv sync --frozen
 
 %runscript
     if [ -f /vEcoli/.env ]; then


### PR DESCRIPTION
I came up with a far simpler way to forward the output of a submitted SLURM job to stdout. SLURM `sbatch` has a `--wait` option that blocks until the submitted job finishes, returning an exit code of 1 if the job failed. While waiting, I can use a background thread to poll the output file and forward its contents to stdout. When the submitted job finishes, I can just delete the output file to break the loop in the background thread.

This replaces a lot of custom code and makes it much easier for advanced users to generalize `runscripts/workflow.py` to other HPC schedulers. For reference, SGE has `qsub -sync y`, PBS has `qsub -Wblock=true`, LSF has `bsub -k`, and TORQUE has `qsub -I -x` that work similarly to SLURM's `sbatch --wait`. Unfortunately, I could not find a similar feature for HTCondor's `condor_submit`, which would require some more sophisticated job status monitoring.

Beyond that, I cleaned up some stuff in the documentation, included a more explicit link to the documentation in the README, and (hopefully) properly set the uv cache directory during Singularity image builds (what I tried to do in #319).