### PR TITLE
Google Cloud Fixes

### DIFF
--- a/.github/workflows/docker_security.yml
+++ b/.github/workflows/docker_security.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   security-events: write
   pull-requests: write
+  actions: read
 
 on:
   push:

--- a/.github/workflows/docker_security.yml
+++ b/.github/workflows/docker_security.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches: [master]
   schedule:
     - cron: "0 0 * * *" # Runs daily at midnight UTC
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If your system has git, curl (or wget), and a C compiler
 
 On Ubuntu/Debian, apt can be used to install all three prerequisites:
 
-    sudo -s eval 'apt update && apt install git curl clang'
+    sudo -s eval 'apt update && apt install -y git curl clang'
 
 On MacOS, curl is preinstalled and git and clang come with the Xcode Command Line Tools:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git clone https://github.com/CovertLab/vEcoli.git
 > a new directory called `vEcoli` in your current directory. To speed up
 > the clone and save disk space, add `--filter=blob:none` to the command.
 
-2. [Follow these instructions](https://docs.astral.sh/uv/getting-started/installation/)
+2. [Follow these "Standalone installer" instructions](https://docs.astral.sh/uv/getting-started/installation/)
 to install `uv`, our Python package and project manager of choice.
    
 3. Close and reopen your terminal.

--- a/doc/gcloud.rst
+++ b/doc/gcloud.rst
@@ -123,21 +123,28 @@ right service account and project. Next, install Git and clone the vEcoli reposi
 
 .. code-block:: bash
 
-  sudo apt update && sudo apt install git
-  git clone https://github.com/CovertLab/vEcoli.git
+  # zip and unzip necessary to install SDKMAN to get Java for nextflow
+  sudo apt update && sudo apt install -y git zip unzip
+  git clone https://github.com/CovertLab/vEcoli.git --filter=blob:none
+  cd vEcoli
 
-Now follow the installation instructions from the README starting with
-installing ``uv`` and finishing with installing Nextflow.
+`Install uv <https://docs.astral.sh/uv/getting-started/installation/>`_, then
+create a new virtual environment and install GCSFS:
 
-.. note::
-  Technically, the only requirements to run :mod:`runscripts.workflow` on Google Cloud
-  are Nextflow, Python 3.9+, and `GCSFS <https://gcsfs.readthedocs.io/en/latest/>`_.
-  The workflow steps will be run inside Docker containers (see
-  :ref:`docker-images`). The other Python requirements can be
-  omitted for a more minimal installation. You will need to use
-  :ref:`interactive containers <interactive-containers>` to run the model using
-  any interface other than :mod:`runscripts.workflow`, but this may be a good
-  thing for maximum reproducibility.
+.. code-block:: bash
+
+  source ~/.bashrc
+  uv venv
+  uv pip install gcsfs
+
+Run the following to automatically activate the virtual environment:
+
+.. code-block:: bash
+
+  echo "source ~/vEcoli/.venv/bin/activate" >> ~/.bashrc
+  source ~/.bashrc
+
+Finally, `install Nextflow <https://www.nextflow.io/docs/latest/install.html>`_.
 
 ------------------
 Create Your Bucket

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -732,7 +732,43 @@ class EcoliSim:
                 self.generated_initial_state, initial_environment
             )
 
-    def save_states(self, daughter_outdir: str = ""):
+    def update_experiment(self, time_to_update: float = 0.0):
+        """
+        Runs the E. coli simulation for a specified amount of time. If the
+        simulation reaches a division event and ``config['generations']`` is set,
+        it will save the daughter cell states to JSON files in the directory
+        specified by ``config['daughter_outdir']``. If the simulation reaches
+        the maximum duration specified by ``config['max_duration']``, it will
+        raise a :py:class:`~ecoli.experiments.ecoli_master_sim.TimeLimitError`
+        if ``config['fail_at_max_duration']`` is ``True``.
+        """
+        try:
+            self.ecoli_experiment.update(time_to_update)
+        except DivisionDetected:
+            state = self.ecoli_experiment.state.get_value(condition=not_a_process)
+            assert len(state["agents"]) == 2
+            for i, agent_state in enumerate(state["agents"].values()):
+                prepare_save_state(agent_state)
+                daughter_path = os.path.join(
+                    self.daughter_outdir, f"daughter_state_{i}.json"
+                )
+                write_json(daughter_path, agent_state)
+            print(
+                f"Divided at t = {self.ecoli_experiment.global_time} after"
+                f"{self.ecoli_experiment.global_time - self.initial_global_time} sec."
+            )
+            with open("division_time.sh", "w") as f:
+                f.write(f"export division_time={self.ecoli_experiment.global_time}")
+            # Tell Parquet emitter that simulation was successful
+            if isinstance(self.ecoli_experiment.emitter, ParquetEmitter):
+                self.ecoli_experiment.emitter.success = True
+                self.ecoli_experiment.emitter.finalize()
+            sys.exit()
+        finally:
+            if isinstance(self.ecoli_experiment.emitter, ParquetEmitter):
+                self.ecoli_experiment.emitter.finalize()
+
+    def save_states(self):
         """
         Runs the simulation while saving the states of specific
         timesteps to files named ``data/vivecoli_t{time}.json``. Invoked by
@@ -740,12 +776,6 @@ class EcoliSim:
         if ``config['save'] == True``. State is saved as a JSON that
         can be reloaded into a simulation as described in
         :py:meth:`~ecoli.composites.ecoli_master.Ecoli.initial_state`.
-
-        Args:
-            daughter_outdir: Location to write JSON files for daughter cell(s).
-                Only used if ``config`` contains ``generations`` key specifying
-                number of generations to simulate. Nextflow chains simulations
-                together by passing saved daughter states to new processes.
         """
         for time in self.save_times:
             if time > self.max_duration:
@@ -759,27 +789,7 @@ class EcoliSim:
                 time_to_next_save = self.save_times[i]
             else:
                 time_to_next_save = self.save_times[i] - self.save_times[i - 1]
-            try:
-                self.ecoli_experiment.update(time_to_next_save)
-            except DivisionDetected:
-                state = self.ecoli_experiment.state.get_value(condition=not_a_process)
-                assert len(state["agents"]) == 2
-                for i, agent_state in enumerate(state["agents"].values()):
-                    prepare_save_state(agent_state)
-                    daughter_path = os.path.join(
-                        daughter_outdir, f"daughter_state_{i}.json"
-                    )
-                    write_json(daughter_path, agent_state)
-                print(
-                    f"Divided at t = {self.ecoli_experiment.global_time} after"
-                    f"{self.ecoli_experiment.global_time - self.initial_global_time} sec."
-                )
-                with open("division_time.sh", "w") as f:
-                    f.write(f"export division_time={self.ecoli_experiment.global_time}")
-                # Tell Parquet emitter that simulation was successful
-                if isinstance(self.ecoli_experiment.emitter, ParquetEmitter):
-                    self.ecoli_experiment.emitter.success = True
-                sys.exit()
+            self.update_experiment(time_to_next_save)
             time_elapsed = self.save_times[i]
             state = self.ecoli_experiment.state.get_value(condition=not_a_process)
             if self.divide:
@@ -791,7 +801,7 @@ class EcoliSim:
             print("Finished saving the state at t = " + str(time_elapsed))
         time_remaining = self.max_duration - self.save_times[-1]
         if time_remaining:
-            self.ecoli_experiment.update(time_remaining)
+            self.update_experiment(time_remaining)
 
     def run(self):
         """Create and run an EcoliSim experiment.
@@ -890,29 +900,9 @@ class EcoliSim:
 
         # run the experiment
         if self.save:
-            self.save_states(self.daughter_outdir)
+            self.save_states()
         else:
-            try:
-                self.ecoli_experiment.update(self.max_duration)
-            except DivisionDetected:
-                state = self.ecoli_experiment.state.get_value(condition=not_a_process)
-                assert len(state["agents"]) == 2
-                for i, agent_state in enumerate(state["agents"].values()):
-                    prepare_save_state(agent_state)
-                    daughter_path = os.path.join(
-                        self.daughter_outdir, f"daughter_state_{i}.json"
-                    )
-                    write_json(daughter_path, agent_state)
-                print(
-                    f"Divided at t = {self.ecoli_experiment.global_time} after"
-                    f"{self.ecoli_experiment.global_time - self.initial_global_time} sec."
-                )
-                with open("division_time.sh", "w") as f:
-                    f.write(f"export division_time={self.ecoli_experiment.global_time}")
-                # Tell Parquet emitter that simulation was successful
-                if isinstance(self.ecoli_experiment.emitter, ParquetEmitter):
-                    self.ecoli_experiment.emitter.success = True
-                sys.exit()
+            self.update_experiment(self.max_duration)
         self.ecoli_experiment.end()
         if self.profile:
             report_profiling(self.ecoli_experiment.stats)

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -1,4 +1,3 @@
-import atexit
 import os
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable, cast, Mapping, Optional

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -1,5 +1,6 @@
 import atexit
 import os
+import sys
 from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable, cast, Mapping, Optional
 from urllib import parse
@@ -7,9 +8,9 @@ from urllib import parse
 import duckdb
 import numpy as np
 import polars as pl
+from pyarrow import fs
 from polars.datatypes import DataTypeClass
 from fsspec.core import filesystem, url_to_fs, OpenFile
-from fsspec.spec import AbstractFileSystem
 from tqdm import tqdm
 from vivarium.core.emitter import Emitter
 
@@ -65,7 +66,7 @@ def json_to_parquet(
     emit_dict: dict[str, np.ndarray | list[pl.Series]],
     outfile: str,
     schema: dict[str, Any],
-    filesystem: AbstractFileSystem,
+    filesystem: fs.FileSystem,
 ):
     """Convert dictionary to Parquet.
 
@@ -74,7 +75,7 @@ def json_to_parquet(
             or lists of Polars Series (variable-shape).
         outfile: Path to output Parquet file. Can be local path or URI.
         schema: Full mapping of column names to Polars dtypes.
-        filesystem: On local filesystem, fsspec filesystem needed to
+        filesystem: On local filesystem, PyArrow filesystem needed to
             write Parquet file atomically.
     """
     tbl = pl.DataFrame(emit_dict, schema={k: schema[k] for k in emit_dict})
@@ -82,11 +83,13 @@ def json_to_parquet(
     # trying to read partially written Parquet files. Get around this by writing
     # to a temporary file and then renaming it to the final output file.
     temp_outfile = outfile
-    if parse.urlparse(outfile).scheme in ("", "file", "local"):
+    parsed_outfile = parse.urlparse(outfile)
+    if parsed_outfile.scheme in ("", "file", "local"):
+        outfile = os.path.join(parsed_outfile.netloc, parsed_outfile.path)
         temp_outfile = outfile + ".tmp"
     tbl.write_parquet(temp_outfile, statistics=False)
     if temp_outfile != outfile:
-        filesystem.mv(temp_outfile, outfile)
+        filesystem.move(temp_outfile, outfile)
 
 
 def union_by_name(query_sql: str) -> str:
@@ -835,8 +838,7 @@ class ParquetEmitter(Emitter):
             self.out_uri = os.path.abspath(config["out_dir"])
         else:
             self.out_uri = config["out_uri"]
-        self.filesystem: AbstractFileSystem
-        self.filesystem, _ = url_to_fs(self.out_uri)
+        self.filesystem, self.out_dir = fs.FileSystem.from_uri(self.out_uri)
         self.batch_size = config.get("batch_size", 400)
         self.threaded = config.get("threaded", True)
         if self.threaded:
@@ -866,41 +868,54 @@ class ParquetEmitter(Emitter):
         this is done by :py:class:`~ecoli.experiments.ecoli_master_sim.EcoliSim`
         upon reaching division.
         """
-        # Wait for last batch to finish writing
-        self.last_batch_future.result()
-        # Flush any remaining buffered emits to Parquet
-        outfile = os.path.join(
-            self.out_uri,
-            self.experiment_id,
-            "history",
-            self.partitioning_path,
-            f"{self.num_emits}.pq",
-        )
-        self.filesystem.makedirs(os.path.dirname(outfile), exist_ok=True)
-        if not self.filesystem.exists(outfile):
-            for k, v in self.buffered_emits.items():
-                self.buffered_emits[k] = v[: self.num_emits % self.batch_size]
-            json_to_parquet(
-                self.buffered_emits, outfile, self.pl_types, self.filesystem
-            )
-        # Hive-partitioned directory that only contains successful sims
-        if self.success:
-            success_file = os.path.join(
+        try:
+            # Wait for last batch to finish writing
+            self.last_batch_future.result()
+            # Flush any remaining buffered emits to Parquet
+            outfile = os.path.join(
                 self.out_uri,
                 self.experiment_id,
-                "success",
+                "history",
                 self.partitioning_path,
-                "s.pq",
+                f"{self.num_emits}.pq",
             )
-            try:
-                self.filesystem.delete(os.path.dirname(success_file), recursive=True)
-            except (FileNotFoundError, OSError):
-                pass
-            self.filesystem.makedirs(os.path.dirname(success_file))
-            pl.DataFrame({"success": [True]}).write_parquet(
-                success_file,
-                statistics=False,
+            # PyArrow filesystem requires path, not URI
+            self.filesystem.create_dir(
+                self.out_dir + os.path.dirname(outfile)[len(self.out_uri) :]
             )
+            # Write remaining buffered emits
+            if self.num_emits % self.batch_size != 0:
+                for k, v in self.buffered_emits.items():
+                    self.buffered_emits[k] = v[: self.num_emits % self.batch_size]
+                json_to_parquet(
+                    self.buffered_emits, outfile, self.pl_types, self.filesystem
+                )
+            # Hive-partitioned directory that only contains successful sims
+            if self.success:
+                success_file = os.path.join(
+                    self.out_uri,
+                    self.experiment_id,
+                    "success",
+                    self.partitioning_path,
+                    "s.pq",
+                )
+                success_dir = (
+                    self.out_dir + os.path.dirname(success_file)[len(self.out_uri) :]
+                )
+                try:
+                    self.filesystem.delete_dir(success_dir)
+                except (FileNotFoundError, OSError):
+                    pass
+                self.filesystem.create_dir(success_dir)
+                pl.DataFrame({"success": [True]}).write_parquet(
+                    success_file,
+                    statistics=False,
+                )
+        except Exception as e:
+            # Since Python ignores exceptions in atexit callbacks,
+            # we need to explicitly set the exit code
+            print(f"Error during ParquetEmitter finalization: {e}", file=sys.stderr)
+            os._exit(1)
 
     def emit(self, data: dict[str, Any]):
         """
@@ -971,13 +986,14 @@ class ParquetEmitter(Emitter):
                 self.partitioning_path,
                 "config.pq",
             )
+            config_dir = self.out_dir + os.path.dirname(outfile)[len(self.out_uri) :]
             # Cleanup any existing output files from previous runs then
             # create new folder for config / simulation output
             try:
-                self.filesystem.delete(os.path.dirname(outfile), recursive=True)
+                self.filesystem.delete_dir(config_dir)
             except (FileNotFoundError, OSError):
                 pass
-            self.filesystem.makedirs(os.path.dirname(outfile))
+            self.filesystem.create_dir(config_dir)
             self.last_batch_future = self.executor.submit(
                 json_to_parquet,
                 config_emit,
@@ -987,13 +1003,13 @@ class ParquetEmitter(Emitter):
             )
             # Delete any sim output files in final filesystem
             history_outdir = os.path.join(
-                self.out_uri, self.experiment_id, "history", self.partitioning_path
+                self.out_dir, self.experiment_id, "history", self.partitioning_path
             )
             try:
-                self.filesystem.delete(history_outdir, recursive=True)
+                self.filesystem.delete_dir(history_outdir)
             except (FileNotFoundError, OSError):
                 pass
-            self.filesystem.makedirs(history_outdir)
+            self.filesystem.create_dir(history_outdir)
             return
         # Each Engine that uses this emitter should only simulate a single cell
         # In lineage simulations, StopAfterDivision Step will terminate

--- a/ecoli/library/test_parquet_emitter.py
+++ b/ecoli/library/test_parquet_emitter.py
@@ -1,4 +1,3 @@
-import atexit
 import os
 import re
 import tempfile

--- a/ecoli/processes/engine_process.py
+++ b/ecoli/processes/engine_process.py
@@ -509,7 +509,7 @@ class EngineProcess(Process):
             self.sim.run_for(timestep)
             if force_complete:
                 self.sim.complete()
-        except Exception:
+        except (Exception, KeyboardInterrupt):
             if isinstance(self.emitter, ParquetEmitter):
                 self.emitter.finalize()
             raise

--- a/ecoli/processes/engine_process.py
+++ b/ecoli/processes/engine_process.py
@@ -505,9 +505,15 @@ class EngineProcess(Process):
         self.emitter.emit(emit_config)
 
         # Run inner simulation for timestep.
-        self.sim.run_for(timestep)
-        if force_complete:
-            self.sim.complete()
+        try:
+            self.sim.run_for(timestep)
+            if force_complete:
+                self.sim.complete()
+        except Exception:
+            if isinstance(self.emitter, ParquetEmitter):
+                self.emitter.success = True
+                self.emitter.finalize()
+            raise
 
         update = {}
 
@@ -520,7 +526,7 @@ class EngineProcess(Process):
             # Finalize emits before division
             if isinstance(self.emitter, ParquetEmitter):
                 self.emitter.success = True
-                self.emitter._finalize()
+                self.emitter.finalize()
             # Perform division.
             daughters = []
             daughter_states = self.sim.state.divide_value()

--- a/ecoli/processes/engine_process.py
+++ b/ecoli/processes/engine_process.py
@@ -511,7 +511,6 @@ class EngineProcess(Process):
                 self.sim.complete()
         except Exception:
             if isinstance(self.emitter, ParquetEmitter):
-                self.emitter.success = True
                 self.emitter.finalize()
             raise
 

--- a/runscripts/container/Dockerfile
+++ b/runscripts/container/Dockerfile
@@ -14,8 +14,11 @@ RUN echo "alias ls='ls --color=auto'" >> ~/.bashrc \
     && echo "alias ll='ls -l'" >> ~/.bashrc \
     && cp ~/.bashrc /
 
+# gcc necessary for compiling C extensions in some Python packages.
 # procps necessary for `ps` command used by Nextflow to track processes.
-RUN apt-get update && apt-get install -y gcc procps nano
+# nano is a text editor for convenience.
+# curl is necessary for authentication on Google Cloud VMs
+RUN apt-get update && apt-get install -y gcc procps nano curl
 
 # Install the project into `/vEcoli`
 WORKDIR /vEcoli

--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -27,6 +27,6 @@ From: ghcr.io/astral-sh/uv@sha256:1cc0392c8aad8026ef3922e3f997fff0f31e506b0ffe95
     FILES_TO_ADD
 
 %post
-    apt-get update && apt-get install -y gcc procps nano
+    apt-get update && apt-get install -y gcc procps nano curl
     cd /vEcoli
     UV_CACHE_DIR="/vEcoli/.uv_cache" UV_COMPILE_BYTECODE=1 uv sync --frozen

--- a/runscripts/sim.py
+++ b/runscripts/sim.py
@@ -20,11 +20,10 @@ def main():
     proc = subprocess.Popen(cmd)
     try:
         proc.wait()
-    # Give subprocess chance to finish cleanly
-    except Exception:
+    # Ensure emits are finalized even if wrapper is interrupted
+    finally:
         proc.send_signal(signal.SIGINT)
         proc.wait()
-        raise
     return proc.returncode
 
 

--- a/runscripts/sim.py
+++ b/runscripts/sim.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import sys
 import subprocess
 
@@ -16,8 +17,15 @@ def main():
     # Forward all arguments
     cmd = [sys.executable, script_path] + sys.argv[1:]
     # Execute and forward exit code
-    result = subprocess.run(cmd)
-    return result.returncode
+    proc = subprocess.Popen(cmd)
+    try:
+        proc.wait()
+    # Give subprocess chance to finish cleanly
+    except Exception as e:
+        proc.send_signal(signal.SIGINT)
+        proc.wait()
+        raise e
+    return proc.returncode
 
 
 if __name__ == "__main__":

--- a/runscripts/sim.py
+++ b/runscripts/sim.py
@@ -21,10 +21,10 @@ def main():
     try:
         proc.wait()
     # Give subprocess chance to finish cleanly
-    except Exception as e:
+    except Exception:
         proc.send_signal(signal.SIGINT)
         proc.wait()
-        raise e
+        raise
     return proc.returncode
 
 

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -435,6 +435,7 @@ def main():
                 "Please use a different experiment ID or output directory. "
                 "Alternatively, move, delete, or rename the existing directory."
             )
+        os.makedirs(outdir, exist_ok=True)
     else:
         if filesystem.exists(exp_outdir) and not args.resume:
             raise RuntimeError(
@@ -442,6 +443,7 @@ def main():
                 "Please use a different experiment ID or output directory. "
                 "Alternatively, move, delete, or rename the existing directory."
             )
+        filesystem.makedirs(outdir, exist_ok=True)
     temp_config_path = f"{local_outdir}/workflow_config.json"
     final_config_path = os.path.join(outdir, "workflow_config.json")
     final_config_uri = os.path.join(out_uri, "workflow_config.json")

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -423,14 +423,25 @@ def main():
         config["lineage_seed"] = random.randint(0, 2**31 - 1)
     filesystem, outdir = parse_uri(out_uri)
     outdir = os.path.join(outdir, experiment_id, "nextflow")
+    exp_outdir = os.path.join(outdir, experiment_id)
     out_uri = os.path.join(out_uri, experiment_id, "nextflow")
     repo_dir = os.path.dirname(os.path.dirname(__file__))
     local_outdir = os.path.join(repo_dir, "nextflow_temp", experiment_id)
     os.makedirs(local_outdir, exist_ok=True)
     if filesystem is None:
-        os.makedirs(outdir, exist_ok=args.resume)
+        if os.path.exists(exp_outdir) and not args.resume:
+            raise RuntimeError(
+                f"Output directory already exists: {exp_outdir}. "
+                "Please use a different experiment ID or output directory. "
+                "Alternatively, move, delete, or rename the existing directory."
+            )
     else:
-        filesystem.makedirs(outdir, exist_ok=args.resume)
+        if filesystem.exists(exp_outdir) and not args.resume:
+            raise RuntimeError(
+                f"Output directory already exists: {exp_outdir}. "
+                "Please use a different experiment ID or output directory. "
+                "Alternatively, move, delete, or rename the existing directory."
+            )
     temp_config_path = f"{local_outdir}/workflow_config.json"
     final_config_path = os.path.join(outdir, "workflow_config.json")
     final_config_uri = os.path.join(out_uri, "workflow_config.json")

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -423,7 +423,7 @@ def main():
         config["lineage_seed"] = random.randint(0, 2**31 - 1)
     filesystem, outdir = parse_uri(out_uri)
     outdir = os.path.join(outdir, experiment_id, "nextflow")
-    exp_outdir = os.path.join(outdir, experiment_id)
+    exp_outdir = os.path.dirname(outdir)
     out_uri = os.path.join(out_uri, experiment_id, "nextflow")
     repo_dir = os.path.dirname(os.path.dirname(__file__))
     local_outdir = os.path.join(repo_dir, "nextflow_temp", experiment_id)

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -409,7 +409,7 @@ def main():
     else:
         out_uri = config["emitter_arg"]["out_uri"]
         parsed_uri = parse.urlparse(out_uri)
-        if parsed_uri.schema not in ("local", "file") and not FSSPEC_AVAILABLE:
+        if parsed_uri.scheme not in ("local", "file") and not FSSPEC_AVAILABLE:
             raise RuntimeError(
                 f"URI '{out_uri}' specified but fsspec is not available. "
                 "Install fsspec or provide a local URI/out directory."


### PR DESCRIPTION
Addresses some issues with deploying on Google Cloud that cropped up since I last tested it.
- Streamline setup process with more explicit instructions
- Explicitly install `curl` to fix authentication via the metadata server on Compute Engine
- Implement more robust output overwrite protection and fix typo in `runscripts/workflow.py`
- Explicitly call `ecoli.library.parquet_emitter.ParquetEmitter.finalize()` in `try...finally` block to write remaining buffered emits if exception is raised. This gets around some limitations of the previous `atexit` hook approach. For one, exceptions raised in `atexit` hooks were ignored and not reflected in the final exit code. When the hook failed in a Nextflow workflow, the user would get no indication of this unless they manually checked the stderr. Additionally, `atexit` hooks do not allow new futures to be scheduled (after interpreter shutdown), breaking GCSFS which uses `asyncio`.

Other
- Add actions read permission to Docker security scan job to fix failures on forks of the repo
- Run Docker security scan job on PRs to draw attention to any detected security vulnerabilities