### PR TITLE
Bug fixes

### DIFF
--- a/ecoli/library/parameters.py
+++ b/ecoli/library/parameters.py
@@ -685,8 +685,9 @@ def main():
             value_str = "{:.2e}".format(row.param.value.to(row.units).magnitude)
             if "e" in value_str:
                 base, exponent = value_str.split("e")
-                exponent = exponent.strip("+-0")
-                base = base.strip("0")
+                exponent = int(exponent)
+                if "." in base:
+                    base = base.rstrip("0").rstrip(".")
                 if exponent:
                     value_str = "%s \\times 10^{%s}" % (base, exponent)
                 else:

--- a/runscripts/analysis.py
+++ b/runscripts/analysis.py
@@ -292,6 +292,17 @@ def main():
         }
         variant_names = {config["experiment_id"][0]: variant_name}
 
+    # Save copy of config JSON with parameters for plots
+    metadata_path = os.path.join(os.path.abspath(config["outdir"]), "metadata.json")
+    if os.path.exists(metadata_path):
+        raise FileExistsError(
+            f"{metadata_path} already exists, indicating an analysis has "
+            f"been run with output directory {config['outdir']}. Please "
+            "delete/move it or specify a different output directory."
+        )
+    with open(metadata_path, "w") as f:
+        json.dump(config, f)
+
     # Establish DuckDB connection
     conn = create_duckdb_conn(out_uri, gcs_bucket, config.get("cpus"))
     history_sql, config_sql, success_sql = dataset_sql(out_uri, config["experiment_id"])
@@ -370,12 +381,6 @@ def main():
                     variant_metadata,
                     variant_names,
                 )
-
-    # Save copy of config JSON with parameters for plots
-    with open(
-        os.path.join(os.path.abspath(config["outdir"]), "metadata.json"), "w"
-    ) as f:
-        json.dump(config, f)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, the automatic LaTeX table generation code in `ecoli/library/parameters.py` used `strip` to format the exponent, which would incorrectly remove `-` signs and non-decimal trailing zeros. This PR fixes this by casting the exponent string to an integer, which correctly strips leading `+` signs and removes trailing zeros after decimal points.

Previously, `runscripts/analysis.py` would silently overwrite the `metadata.json` file saved with each run. This PR fixes this by raising an error if the `metadata.json` file already exists, telling the user to either delete/move the existing output directory or choose a different one.