### PR TITLE
Cleaner Apptainer image definition

### DIFF
--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -12,7 +12,7 @@ From: ghcr.io/astral-sh/uv@sha256:1cc0392c8aad8026ef3922e3f997fff0f31e506b0ffe95
     export UV_CACHE_DIR="/vEcoli/.uv_cache"
     # runscripts/container/build-image.sh has some custom logic to replace this
     # with the environment variables that are set in .env
-    DOT_ENV_VARS
+    {{ dot_env_vars }}
 
 %labels
     application "Whole Cell Model Runtime Environment"

--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -25,7 +25,7 @@ From: ghcr.io/astral-sh/uv@sha256:1cc0392c8aad8026ef3922e3f997fff0f31e506b0ffe95
     repo.tar /repo.tar
 
 %post
-    tar -xvf /repo.tar -C /vEcoli
+    tar -xf /repo.tar -C /vEcoli
     rm /repo.tar
     apt-get update && apt-get install -y gcc procps nano curl
     cd /vEcoli

--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -22,11 +22,11 @@ From: ghcr.io/astral-sh/uv@sha256:1cc0392c8aad8026ef3922e3f997fff0f31e506b0ffe95
     website "https://www.covert.stanford.edu/"
 
 %files
-    # runscripts/container/build-image.sh has some custom logic to replace this
-    # with a set of files that honors .dockerignore
-    FILES_TO_ADD
+    repo.tar /repo.tar
 
 %post
+    tar -xvf /repo.tar -C /vEcoli
+    rm /repo.tar
     apt-get update && apt-get install -y gcc procps nano curl
     cd /vEcoli
     UV_CACHE_DIR="/vEcoli/.uv_cache" UV_COMPILE_BYTECODE=1 uv sync --frozen

--- a/runscripts/container/build-image.sh
+++ b/runscripts/container/build-image.sh
@@ -96,11 +96,9 @@ elif [ "$BUILD_APPTAINER" -ne 0 ]; then
       grep -v "^#" "$ignore_file" | grep -v "^$" | grep -v "^!" | while read -r pattern; do
           # Handle patterns starting with / (root-relative)
           if [[ "$pattern" == /* ]]; then
-            echo ".${pattern}" >>"$EXCLUDE_PATTERNS"
             echo ".${pattern}/*" >>"$EXCLUDE_PATTERNS"
           # Handle directory patterns ending with /
           elif [[ "$pattern" == */ ]]; then
-            echo "./${pattern}" >>"$EXCLUDE_PATTERNS"
             echo "./${pattern}*" >>"$EXCLUDE_PATTERNS"
           # Handle other patterns
           else
@@ -123,14 +121,14 @@ elif [ "$BUILD_APPTAINER" -ne 0 ]; then
 
   echo "Executing: $FIND_CMD"
   # Execute the dynamically generated find command
-  eval "$FIND_CMD -print0 | xargs -0 tar -cvf repo.tar"
+  eval "$FIND_CMD -print0 | xargs -0 tar -cf repo.tar"
 
   # Debug output
-  echo "Found $(du -sh repo.tar) of files to include in the image"
+  echo "Found $(du -sh repo.tar | awk '{print $1}') of files to include in the image"
   TEMP_FILES+=("repo.tar")
 
   # Initialize environment variables string
-  DOT_ENV_VARS=""
+  DOT_ENV_VARS="    "
   # Check if .env file exists
   if [ -f ".env" ]; then
       echo "Processing .env for Singularity environment..."
@@ -141,7 +139,7 @@ elif [ "$BUILD_APPTAINER" -ne 0 ]; then
               # Strip any existing 'export ' prefix
               line=${line#export }
               # Add to environment variables string with export prefix
-              DOT_ENV_VARS+="    export $line"$'\n'
+              DOT_ENV_VARS+="export $line; "
           fi
       done < ".env"
       echo "Found $(echo "$DOT_ENV_VARS" | grep -c 'export ') environment variables"

--- a/runscripts/container/build-image.sh
+++ b/runscripts/container/build-image.sh
@@ -149,17 +149,6 @@ elif [ "$BUILD_APPTAINER" -ne 0 ]; then
       echo "Warning: .env not found"
   fi
 
-  # Read the Singularity file line by line
-  while IFS= read -r line; do
-    if [[ "$line" == *"DOT_ENV_VARS"* ]]; then
-      echo "$DOT_ENV_VARS" >> "$TEMP_DEF"
-    else
-      # Otherwise just add the line as-is
-      echo "$line" >>"$TEMP_DEF"
-    fi
-  done <runscripts/container/Singularity
-
-  echo "Using temporary definition file: $TEMP_DEF"
   echo "=== Building Apptainer Image: ${IMAGE} ==="
   echo "=== git hash ${GIT_HASH}, git branch ${GIT_BRANCH} ==="
 
@@ -170,7 +159,8 @@ elif [ "$BUILD_APPTAINER" -ne 0 ]; then
     --build-arg git_hash="${GIT_HASH}" \
     --build-arg git_branch="${GIT_BRANCH}" \
     --build-arg timestamp="${TIMESTAMP}" \
-    "${IMAGE}" "$TEMP_DEF"; do
+    --build-arg dot_env_vars="${DOT_ENV_VARS}" \
+    "${IMAGE}" runscripts/container/Singularity; do
     if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
         echo "ERROR: Apptainer build failed after $MAX_ATTEMPTS attempts."
         exit 1


### PR DESCRIPTION
Previously, after using `find` to get all files to include in the Apptainer image (everything not excluded by `.dockerignore`, give or take), all of the file names would be pasted directly into the image definition file. This works for now, but apparently there is a 64,000 character limit on image definition sections. This is the default per-token limit for the Go parser that Apptainer uses, and Apptainer defines a token to be an entire section of a definition file (see [source code](https://github.com/apptainer/apptainer/blob/dd820ea216d01381b114d773eac5a97d71a3ceaa/pkg/build/types/parser/deffile.go#L55-L66)). We easily hit this limit with just a few extra files in the repo.

This PR fixes this by creating a tar archive of all the files to include, copying the archive into the image, then extracting it during setup.