### PR TITLE
Update security update PR body even when contents do not change

### DIFF
--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -70,8 +70,14 @@ jobs:
           REMOTE_FILE_SHA=$(gh api "repos/$REPO/contents/uv.lock?ref=$BRANCH" \
             --jq '.sha' 2>/dev/null || echo "")
           LOCAL_FILE_SHA=$(git hash-object uv.lock)
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
           if [ "$REMOTE_FILE_SHA" = "$LOCAL_FILE_SHA" ]; then
             echo "uv.lock already matches remote $BRANCH, skipping push"
+            if echo "$PR_NUMBER" | grep -q '^[0-9]'; then
+              echo "Updating body of existing PR #$PR_NUMBER"
+              gh pr edit "$PR_NUMBER" \
+                --body-file vulnerability_report.md
+            fi
             exit 0
           fi
 
@@ -114,7 +120,6 @@ jobs:
               -f sha="$COMMIT_SHA"
           fi
 
-          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
           if echo "$PR_NUMBER" | grep -q '^[0-9]'; then
             gh pr edit "$PR_NUMBER" \
               --body-file vulnerability_report.md

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -72,13 +72,14 @@ jobs:
           LOCAL_FILE_SHA=$(git hash-object uv.lock)
           PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
           if [ "$REMOTE_FILE_SHA" = "$LOCAL_FILE_SHA" ]; then
-            echo "uv.lock already matches remote $BRANCH, skipping push"
-            if echo "$PR_NUMBER" | grep -q '^[0-9]'; then
+            echo "uv.lock already matches remote $BRANCH"
+            if echo "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
               echo "Updating body of existing PR #$PR_NUMBER"
               gh pr edit "$PR_NUMBER" \
                 --body-file vulnerability_report.md
+              exit 0
             fi
-            exit 0
+            echo "No open PR found for $BRANCH; continuing to PR create/edit logic"
           fi
 
           # Build a new signed commit via the REST API (required for commit signing)
@@ -120,7 +121,7 @@ jobs:
               -f sha="$COMMIT_SHA"
           fi
 
-          if echo "$PR_NUMBER" | grep -q '^[0-9]'; then
+          if echo "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
             gh pr edit "$PR_NUMBER" \
               --body-file vulnerability_report.md
           else


### PR DESCRIPTION
Currently, if the pip-audit workflow detects that the proposed dependency updates do not change the PR diff, it does not update the PR branch or body. This means that if any new currently unpatched, vulnerabilities are discovered, they are not reflected in the PR body. This PR fixes that by still updating the PR body even if the PR contents do not change.