### PR TITLE
Upload SARIF action requires `actions: read` permission on private repo

### DIFF
--- a/.github/workflows/docker_security.yml
+++ b/.github/workflows/docker_security.yml
@@ -21,6 +21,7 @@ jobs:
   buildx:
     permissions:
       contents: read
+      actions: read            # Required for upload-sarif to get workflow run info
       security-events: write   # Required for uploading SARIF results
       pull-requests: write     # Required for PR comments summarizing vulnerabilities
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
With this commit, the Docker Scout GHA completed successfully on https://github.com/CovertLabEcoli/vEcoli-private/pull/67. Compare that to https://github.com/CovertLabEcoli/vEcoli-private/pull/66, which has all the public changes except this one.