### PR TITLE
Ignore local workflow job failures

### DIFF
--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -310,5 +310,8 @@ profiles {
     }
     standard {
         params.projectRoot = "${launchDir}"
+        process {
+            errorStrategy = 'ignore'
+        }
     }
 }


### PR DESCRIPTION
Individual simulation failures were causing entire workflows to crash when run locally because I accidentally dropped the local `errorStrategy` in my recent Nextflow-related refactoring. This PR adds that logic back.