### PR TITLE
Update base container image

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
-          version: "0.10.6"
+          version: "0.11.8"
       - name: Install Pandoc
         run: sudo apt-get install pandoc
       - name: Install model

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
-          version: "0.10.6"
+          version: "0.11.8"
       - name: Install Pandoc
         run: sudo apt-get install pandoc
       - name: Install model

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -25,10 +25,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
-          version: "0.10.6"
+          version: "0.11.8"
 
       - name: Install pip-audit and packaging
         run: |

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -38,10 +38,10 @@ jobs:
       with:
           persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.10.6"
+        version: "0.11.8"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen
     - name: Test ParCa reproducibility
@@ -86,10 +86,10 @@ jobs:
       with:
           persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.10.6"
+        version: "0.11.8"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen
     - name: Install nextflow edge

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,10 +24,10 @@ jobs:
       with:
           persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.10.6"
+        version: "0.11.8"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Cache ParCa simulation data
@@ -55,10 +55,10 @@ jobs:
       with:
           persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.10.6"
+        version: "0.11.8"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Mypy
@@ -71,10 +71,10 @@ jobs:
       with:
           persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.10.6"
+        version: "0.11.8"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Ruff

--- a/runscripts/container/Dockerfile
+++ b/runscripts/container/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Use runscripts/container/build-image.sh to build.
 
-FROM ghcr.io/astral-sh/uv@sha256:a265bdb0593070eee9dfededde2e9d586917f64cfd297e290d78584e473d81e4
+FROM ghcr.io/astral-sh/uv@sha256:de254da1c9abae7926e5cf29a6ab4a5ea65d3290682d88aa416445fa3de681bf
 
 LABEL application="Whole Cell Model of Escherichia coli" \
     email="wholecellteam@lists.stanford.edu" \

--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: ghcr.io/astral-sh/uv@sha256:a265bdb0593070eee9dfededde2e9d586917f64cfd297e290d78584e473d81e4
+From: ghcr.io/astral-sh/uv@sha256:de254da1c9abae7926e5cf29a6ab4a5ea65d3290682d88aa416445fa3de681bf
 
 # Refer to Dockerfile for comments about build process. Apptainer does not
 # support layer caching which results in a much less interesting build file.


### PR DESCRIPTION
This PR updates the base uv image for our container builds from [0.9.28-trixie-slim](https://github.com/astral-sh/uv/pkgs/container/uv/663133865?tag=0.9.28-trixie-slim) to [0.11.8-trixie-slim](https://github.com/astral-sh/uv/pkgs/container/uv/824398953?tag=0.11.8-trixie-slim). I did this partly to bust the GitHub Actions Docker build cache and make it pull the latest versions of several packages with known security vulnerabilities (e.g., OpenSSL). This should silence most of the false positive vulnerabilities flagged by the Docker Scout GHA.

It also updates our GitHub Actions CI jobs to use uv 0.11.8.