### PR TITLE
Fix `emit_paths`

### DIFF
--- a/configs/test_emit_paths.json
+++ b/configs/test_emit_paths.json
@@ -1,0 +1,11 @@
+{
+    "experiment_id": "test_emit_paths",
+    "suffix_time": false,
+    "max_duration": 2,
+    "log_updates": true,
+    "emit_paths": [
+        ["listeners", "mass", "cell_mass"],
+        ["log_update", "ecoli-mass-listener", "listeners", "mass", "dry_mass"]
+    ],
+    "emitter": "parquet"
+}

--- a/configs/test_emit_paths.json
+++ b/configs/test_emit_paths.json
@@ -2,10 +2,9 @@
     "experiment_id": "test_emit_paths",
     "suffix_time": false,
     "max_duration": 2,
-    "log_updates": true,
     "emit_paths": [
         ["listeners", "mass", "cell_mass"],
-        ["log_update", "ecoli-mass-listener", "listeners", "mass", "dry_mass"]
+        ["global_time"]
     ],
     "emitter": "parquet"
 }

--- a/doc/composites.rst
+++ b/doc/composites.rst
@@ -90,7 +90,7 @@ The analysis plots located in :py:mod:`~ecoli.analysis.single.blame` can be used
 to visualize these updates.
 
 .. warning::
-    This feature should only be turned for debugging purposes and
+    This feature should only be turned on for debugging purposes and
     only when using the in-memory emitter (see :ref:`ram_emitter`).
     The Parquet emitter is unable to serialize many of the objects
     contained in process updates (e.g., nested lists of inconsistent

--- a/doc/composites.rst
+++ b/doc/composites.rst
@@ -92,6 +92,9 @@ to visualize these updates.
 .. warning::
     This feature should only be turned for debugging purposes and
     only when using the in-memory emitter (see :ref:`ram_emitter`).
+    The Parquet emitter is unable to serialize many of the objects
+    contained in process updates (e.g., nested lists of inconsistent
+    depth like ``[[1], 2]``).
 
 -------------
 Initial State

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -700,6 +700,14 @@ is a list workflow behaviors enabled in our model to handle unexpected errors.
   depends on generation 6, :py:mod:`runscripts.create_variants` depends on
   :py:mod:`runscripts.parca`, etc).
 
+.. warning::
+  The resume option is primarily meant for testing code changes, not config changes.
+  As such, most edits to the configuration JSON are silently ignored when resuming a workflow.
+  The only exceptions are changes to resource allocation options (e.g., ``SIM_MEM``),
+  allowing users to retry failed jobs with higher resource limits without triggering
+  re-execution of already completed jobs. If you want to change other options, you
+  must launch a new workflow. 
+
 .. _output:
 
 ------

--- a/ecoli/composites/ecoli_master_tests.py
+++ b/ecoli/composites/ecoli_master_tests.py
@@ -454,6 +454,41 @@ def test_translation_flag_harness(flag_overrides):
     run_two_second_simulation(flag_overrides)
 
 
+def test_emit_paths():
+    """
+    Test that ``emit_paths`` correctly filters emitted data in the Parquet
+    emitter and that ``log_update`` paths work with ``log_updates = True``.
+
+    Uses ``configs/test_emit_paths.json``
+    """
+    import tempfile
+    from ecoli.library.parquet_emitter import dataset_sql, create_duckdb_conn
+
+    with tempfile.TemporaryDirectory() as out_dir:
+        sim = EcoliSim.from_file(CONFIG_DIR_PATH + "test_emit_paths.json")
+        sim.config["emitter_arg"] = {"out_dir": out_dir}
+        sim.build_ecoli()
+        sim.run()
+        sim.ecoli_experiment.emitter.finalize()
+
+        history_sql, _, _ = dataset_sql(out_dir, [sim.experiment_id])
+        conn = create_duckdb_conn()
+        t = conn.sql(f"SELECT * FROM ({history_sql})").pl()
+
+        id_cols = {
+            "time",
+            "agent_id",
+            "experiment_id",
+            "generation",
+            "lineage_seed",
+            "variant",
+        }
+        emit_paths = {"__".join(col) for col in sim.config["emit_paths"]} | id_cols
+        assert set(t.columns) == emit_paths, (
+            f"Expected columns {emit_paths} but got {set(t.columns)}"
+        )
+
+
 test_library = {
     "1": test_division,
     "2": test_division_topology,
@@ -462,6 +497,7 @@ test_library = {
     "5": test_emit_unique,
     "6": test_translation_flag_harness,
     "7": test_daughter_state_includes_non_agent_state,
+    "8": test_emit_paths,
 }
 
 # run experiments in test_library from the command line with:

--- a/ecoli/composites/ecoli_master_tests.py
+++ b/ecoli/composites/ecoli_master_tests.py
@@ -237,12 +237,8 @@ def test_division(agent_id="0", max_duration=4):
     for name, mols in mother_state["unique"].items():
         d1_state = daughter_states[0]["unique"][name]
         d2_state = daughter_states[1]["unique"][name]
-        mol_keys = sim.ecoli_experiment.state["agents"]["00"]["unique"][
-            name
-        ].value.dtype.names
-        entryState_col = np.where(np.array(mol_keys) == "_entryState")[0][0]
-        n_mother = sum(mols[entryState_col])
-        n_daughter = sum(d1_state[entryState_col]) + sum(d2_state[entryState_col])
+        n_mother = sum(mols["_entryState"])
+        n_daughter = sum(d1_state["_entryState"]) + sum(d2_state["_entryState"])
         if name == "chromosome_domain":
             # Chromosome domain 0 is lost after division because
             # it has been fully split into child domains 1 and 2
@@ -251,8 +247,7 @@ def test_division(agent_id="0", max_duration=4):
             f"{name}: mother has {n_mother}, daughters have {n_daughter}"
         )
         # Assert that no unique mol is in both daughters
-        unique_idx_col = np.where(np.array(mol_keys) == "unique_index")[0][0]
-        assert not (set(d1_state[unique_idx_col]) & set(d2_state[unique_idx_col]))
+        assert not (set(d1_state["unique_index"]) & set(d2_state["unique_index"]))
 
     # asserts
     final_agents = output[max_duration]["agents"].keys()

--- a/ecoli/composites/ecoli_master_tests.py
+++ b/ecoli/composites/ecoli_master_tests.py
@@ -8,6 +8,7 @@ import os
 from itertools import product
 
 import numpy as np
+import polars as pl
 import json
 import tempfile
 import pytest
@@ -27,6 +28,15 @@ from configs import (
     ECOLI_DEFAULT_TOPOLOGY,
 )
 from ecoli.experiments.ecoli_master_sim import EcoliSim, CONFIG_DIR_PATH
+from ecoli.library.parquet_emitter import dataset_sql, create_duckdb_conn
+
+
+@pytest.fixture
+def parquet_out_dir():
+    """Temporary directory for Parquet emitter output."""
+    with tempfile.TemporaryDirectory() as out_dir:
+        yield out_dir
+
 
 TRANSLATION_SUPPLY_FLAGS = [
     "mechanistic_translation_supply",
@@ -415,31 +425,37 @@ def plot_spatial_snapshots(data, sim, experiment_dir="ecoli_test"):
     )
 
 
-def test_emit_unique():
+def test_emit_unique(parquet_out_dir):
     """
-    Test that the ``emit_unique`` configuration option works. This can be broken
+    Verifies that unique molecule data is written to Parquet output when ``emit_unique``
+    is True. Make sure that every unique molecule type has at least one corresponding
+    column, including an integer unique index list. This can be broken
     if a new process is added whose ports schema connects to a unique molecule
     without setting the ``_emit`` property to ``config['emit_unique']``.
     """
     sim = EcoliSim.from_file()
+    sim.config["experiment_id"] = "test_emit_unique_parquet"
     sim.config["emit_unique"] = True
     sim.config["max_duration"] = 1
+    sim.config["emitter"] = "parquet"
+    sim.config["emitter_arg"] = {"out_dir": parquet_out_dir}
     sim.build_ecoli()
     sim.run()
+    sim.ecoli_experiment.emitter.finalize()
+
     unique_molecules = sim.ecoli_experiment.state["agents"]["0"]["unique"].inner.keys()
-    data = sim.query(
-        [
-            (
-                "agents",
-                "0",
-                "unique",
-            )
-        ]
-    )
-    for val in data.values():
-        for unique_mol in unique_molecules:
-            assert unique_mol in val["agents"]["0"]["unique"]
-            assert isinstance(val["agents"]["0"]["unique"][unique_mol], list)
+    history_sql, _, _ = dataset_sql(parquet_out_dir, [sim.experiment_id])
+    conn = create_duckdb_conn()
+    t = conn.sql(f"SELECT * FROM ({history_sql})").pl()
+
+    for unique_mol in unique_molecules:
+        assert any(
+            c == f"unique__{unique_mol}" or c.startswith(f"unique__{unique_mol}__")
+            for c in t.columns
+        ), f"Missing unique molecule '{unique_mol}' in Parquet output"
+        assert t.schema[f"unique__{unique_mol}__unique_index"] == pl.List(pl.Int64), (
+            f"Expected column 'unique__{unique_mol}__unique_index' to have dtype list[int]"
+        )
 
 
 @pytest.mark.slow
@@ -454,39 +470,35 @@ def test_translation_flag_harness(flag_overrides):
     run_two_second_simulation(flag_overrides)
 
 
-def test_emit_paths():
+def test_emit_paths(parquet_out_dir):
     """
-    Test that ``emit_paths`` correctly filters emitted data in the Parquet
-    emitter and that ``log_update`` paths work with ``log_updates = True``.
+    Verifies that only the columns derived from ``emit_paths`` (plus Hive
+    partition ID columns) are written to the Parquet dataset.
 
-    Uses ``configs/test_emit_paths.json``
+    Uses ``configs/test_emit_paths.json``.
     """
-    import tempfile
-    from ecoli.library.parquet_emitter import dataset_sql, create_duckdb_conn
+    sim = EcoliSim.from_file(CONFIG_DIR_PATH + "test_emit_paths.json")
+    sim.config["emitter_arg"] = {"out_dir": parquet_out_dir}
+    sim.build_ecoli()
+    sim.run()
+    sim.ecoli_experiment.emitter.finalize()
 
-    with tempfile.TemporaryDirectory() as out_dir:
-        sim = EcoliSim.from_file(CONFIG_DIR_PATH + "test_emit_paths.json")
-        sim.config["emitter_arg"] = {"out_dir": out_dir}
-        sim.build_ecoli()
-        sim.run()
-        sim.ecoli_experiment.emitter.finalize()
+    history_sql, _, _ = dataset_sql(parquet_out_dir, [sim.experiment_id])
+    conn = create_duckdb_conn()
+    t = conn.sql(f"SELECT * FROM ({history_sql})").pl()
 
-        history_sql, _, _ = dataset_sql(out_dir, [sim.experiment_id])
-        conn = create_duckdb_conn()
-        t = conn.sql(f"SELECT * FROM ({history_sql})").pl()
-
-        id_cols = {
-            "time",
-            "agent_id",
-            "experiment_id",
-            "generation",
-            "lineage_seed",
-            "variant",
-        }
-        emit_paths = {"__".join(col) for col in sim.config["emit_paths"]} | id_cols
-        assert set(t.columns) == emit_paths, (
-            f"Expected columns {emit_paths} but got {set(t.columns)}"
-        )
+    id_cols = {
+        "time",
+        "agent_id",
+        "experiment_id",
+        "generation",
+        "lineage_seed",
+        "variant",
+    }
+    emit_paths = {"__".join(col) for col in sim.config["emit_paths"]} | id_cols
+    assert set(t.columns) == emit_paths, (
+        f"Expected columns {emit_paths} but got {set(t.columns)}"
+    )
 
 
 test_library = {

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -707,7 +707,7 @@ class EcoliSim:
                 "agents",
                 self.agent_id,
             )
-            self.emit_stores = [path + emit_path for emit_path in self.emit_paths]
+        self.emit_stores = [path + emit_path for emit_path in self.emit_paths]
 
         # get initial state
         initial_cell_state = ecoli_composer.initial_state()

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -1094,6 +1094,11 @@ def main():
     ecoli_sim = EcoliSim.from_cli()
     ecoli_sim.build_ecoli()
     ecoli_sim.run()
+    # When max_duration is specified, a simulation can finish without dividing
+    # or raising an Exception. In this case, we still want to finalize the
+    # Parquet emitter to ensure all buffered data is written to file.
+    if isinstance(ecoli_sim.ecoli_experiment.emitter, ParquetEmitter):
+        ecoli_sim.ecoli_experiment.emitter.finalize()
 
 
 if __name__ == "__main__":

--- a/ecoli/experiments/ecoli_master_sim.py
+++ b/ecoli/experiments/ecoli_master_sim.py
@@ -464,6 +464,7 @@ class EcoliSim:
         """
         # Do some datatype pre-processesing
         config["processes"] = {process: None for process in config["processes"]}
+        config["emit_paths"] = [tuple(path) for path in config["emit_paths"]]
 
         # Keep track of base experiment id
         # in case multiple simulations are run with suffix_time = True.
@@ -706,6 +707,7 @@ class EcoliSim:
                 "agents",
                 self.agent_id,
             )
+            self.emit_stores = [path + emit_path for emit_path in self.emit_paths]
 
         # get initial state
         initial_cell_state = ecoli_composer.initial_state()
@@ -852,7 +854,7 @@ class EcoliSim:
         metadata["output_metadata"] = self.output_metadata()
         # make the experiment
         if isinstance(self.emitter, str):
-            self.emitter_config = {"type": self.emitter}
+            self.emitter_config = {"type": self.emitter, "emit_paths": self.emit_paths}
             if self.emitter_arg is not None:
                 for key, value in self.emitter_arg.items():
                     self.emitter_config[key] = value
@@ -920,7 +922,7 @@ class EcoliSim:
         if self.config["emit_paths"]:
             self.ecoli_experiment.state.set_emit_values([tuple()], False)
             self.ecoli_experiment.state.set_emit_values(
-                self.config["emit_paths"],
+                self.emit_stores,
                 True,
             )
 

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -876,11 +876,11 @@ class ParquetEmitter(Emitter):
                         group (optional, default: 400),
                     'threaded': Whether to write Parquet files
                         in a background thread (optional, default: True),
+                    'emit_paths': List of tuple paths to include
+                        in emitted data (optional, omit agent path),
                     # One of the following is REQUIRED
                     'out_dir': local output directory (absolute/relative),
-                    'out_uri': Google Cloud storage bucket URI,
-                    'emit_paths': Optional list of tuple paths to include
-                        in emitted data (agent path omitted).
+                    'out_uri': Google Cloud storage bucket URI
                 }
 
         """

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -878,7 +878,9 @@ class ParquetEmitter(Emitter):
                         in a background thread (optional, default: True),
                     # One of the following is REQUIRED
                     'out_dir': local output directory (absolute/relative),
-                    'out_uri': Google Cloud storage bucket URI
+                    'out_uri': Google Cloud storage bucket URI,
+                    'emit_paths': Optional list of tuple paths to include
+                        in emitted data (agent path omitted).
                 }
 
         """
@@ -909,6 +911,14 @@ class ParquetEmitter(Emitter):
         self.last_batch_future.set_result(None)
         # Set either by EcoliSim or by EngineProcess if sim reaches division
         self.success = False
+        # Convert tuple paths to flat key prefixes for fast filtering
+        emit_paths = config.get("emit_paths", [])
+        if len(emit_paths) > 0:
+            self.emit_prefixes: Optional[set[str]] = {
+                "__".join(path) for path in emit_paths
+            }
+        else:
+            self.emit_prefixes = None
 
     def finalize(self):
         """Convert remaining batched emits to Parquet at sim shutdown
@@ -1054,6 +1064,16 @@ class ParquetEmitter(Emitter):
         for agent_data in data["data"]["agents"].values():
             agent_data["time"] = float(data["data"]["time"])
             agent_data = flatten_dict(agent_data)
+            if self.emit_prefixes is not None:
+                agent_data = {
+                    k: v
+                    for k, v in agent_data.items()
+                    if k == "time"
+                    or any(
+                        k == prefix or k.startswith(prefix + "__")
+                        for prefix in self.emit_prefixes
+                    )
+                }
             emit_idx = self.num_emits % self.batch_size
             # At every emit, each field can take one of two paths.
             #

--- a/ecoli/library/schema.py
+++ b/ecoli/library/schema.py
@@ -242,6 +242,7 @@ def counts(states: np.ndarray, idx: int | np.ndarray) -> np.ndarray:
 class get_bulk_counts(Serializer):
     """Serializer for bulk molecules that saves counts without IDs or masses."""
 
+    @staticmethod
     def serialize(bulk: np.ndarray) -> np.ndarray:
         """
         Args:
@@ -256,6 +257,7 @@ class get_bulk_counts(Serializer):
 class get_unique_fields(Serializer):
     """Serializer for unique molecules."""
 
+    @staticmethod
     def serialize(unique: np.ndarray) -> dict[str, np.ndarray]:
         """
         Args:

--- a/ecoli/library/schema.py
+++ b/ecoli/library/schema.py
@@ -256,15 +256,17 @@ class get_bulk_counts(Serializer):
 class get_unique_fields(Serializer):
     """Serializer for unique molecules."""
 
-    def serialize(unique: np.ndarray) -> list[np.ndarray]:
+    def serialize(unique: np.ndarray) -> dict[str, np.ndarray]:
         """
         Args:
             unique: Numpy structured array of attributes for one unique molecule
 
         Returns:
-            List of contiguous (required by orjson) arrays, one for each attribute
+            Mapping of attributes to contiguous (required by orjson) arrays
         """
-        return [np.ascontiguousarray(unique[field]) for field in unique.dtype.names]
+        return {
+            field: np.ascontiguousarray(unique[field]) for field in unique.dtype.names
+        }
 
 
 def numpy_schema(name: str, emit: bool = True) -> Dict[str, Any]:
@@ -288,7 +290,7 @@ def numpy_schema(name: str, emit: bool = True) -> Dict[str, Any]:
         # Since vivarium-core ensures that each store will only have a single
         # updater, it's OK to create new UniqueNumpyUpdater objects each time
         schema["_updater"] = UniqueNumpyUpdater().updater
-        # Convert to list of contiguous Numpy arrays for faster and more
+        # Convert to dictionary of contiguous Numpy arrays for faster and more
         # efficient serialization (still do not recommend emitting unique)
         schema["_serializer"] = get_unique_fields
         schema["_divider"] = UNIQUE_DIVIDERS[name]

--- a/ecoli/library/test_parquet_emitter.py
+++ b/ecoli/library/test_parquet_emitter.py
@@ -1584,9 +1584,6 @@ class TestEmitPaths:
         )
         emitter.last_batch_future.result()
 
-        assert "listeners__mass__cell_mass" in emitter.buffered_emits or os.path.exists(
-            os.path.join(temp_dir, "test_exp", "history")
-        )
         t = pl.read_parquet(
             os.path.join(temp_dir, "test_exp", "history", "**", "*.pq"),
             hive_partitioning=True,

--- a/ecoli/library/test_parquet_emitter.py
+++ b/ecoli/library/test_parquet_emitter.py
@@ -1531,3 +1531,226 @@ class TestParquetEmitterEdgeCases:
         )
         assert t["nullable_nested"].to_list() == [None] * 4
         assert t["nullable_nested"].dtype == pl.List(pl.List(pl.List(pl.String)))
+
+
+class TestEmitPaths:
+    """Tests for the emit_paths filtering feature."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        tmp = tempfile.mkdtemp()
+        yield tmp
+        shutil.rmtree(tmp)
+
+    def _config_emit(self):
+        return {
+            "table": "configuration",
+            "data": {
+                "experiment_id": "test_exp",
+                "variant": 1,
+                "lineage_seed": 1,
+                "agent_id": "1",
+            },
+        }
+
+    def _sim_emit(self, time=1.0, **agent_fields):
+        return {
+            "table": "simulation",
+            "data": {
+                "time": time,
+                "agents": {"agent1": agent_fields},
+            },
+        }
+
+    def test_no_emit_paths_keeps_all_fields(self, temp_dir):
+        """Without emit_paths, all fields are emitted (existing behavior)."""
+        emitter = ParquetEmitter({"out_dir": temp_dir, "batch_size": 2})
+        assert emitter.emit_prefixes is None
+
+        emitter.emit(self._config_emit())
+        emitter.emit(
+            self._sim_emit(
+                listeners__mass__cell_mass=1.0,
+                listeners__growth__rate=0.5,
+                bulk=np.array([1, 2, 3]),
+            )
+        )
+        emitter.emit(
+            self._sim_emit(
+                listeners__mass__cell_mass=2.0,
+                listeners__growth__rate=0.6,
+                bulk=np.array([4, 5, 6]),
+            )
+        )
+        emitter.last_batch_future.result()
+
+        assert "listeners__mass__cell_mass" in emitter.buffered_emits or os.path.exists(
+            os.path.join(temp_dir, "test_exp", "history")
+        )
+        t = pl.read_parquet(
+            os.path.join(temp_dir, "test_exp", "history", "**", "*.pq"),
+            hive_partitioning=True,
+        )
+        assert "listeners__mass__cell_mass" in t.columns
+        assert "listeners__growth__rate" in t.columns
+        assert "bulk" in t.columns
+
+    def test_emit_paths_filters_fields(self, temp_dir):
+        """With emit_paths, only matching fields (plus time) are buffered."""
+        emitter = ParquetEmitter(
+            {
+                "out_dir": temp_dir,
+                "batch_size": 2,
+                "emit_paths": [("listeners", "mass")],
+            }
+        )
+        assert emitter.emit_prefixes == {"listeners__mass"}
+
+        emitter.emit(self._config_emit())
+        emitter.emit(
+            self._sim_emit(
+                listeners__mass__cell_mass=1.0,
+                listeners__growth__rate=0.5,
+                bulk=np.array([1, 2, 3]),
+            )
+        )
+        emitter.emit(
+            self._sim_emit(
+                listeners__mass__cell_mass=2.0,
+                listeners__growth__rate=0.6,
+                bulk=np.array([4, 5, 6]),
+            )
+        )
+        emitter.last_batch_future.result()
+
+        t = pl.read_parquet(
+            os.path.join(temp_dir, "test_exp", "history", "**", "*.pq"),
+            hive_partitioning=True,
+        )
+        assert "listeners__mass__cell_mass" in t.columns
+        assert "time" in t.columns
+        assert "listeners__growth__rate" not in t.columns
+        assert "bulk" not in t.columns
+
+    def test_emit_paths_exact_key_match(self, temp_dir):
+        """emit_paths should include fields whose flat key exactly equals a prefix."""
+        emitter = ParquetEmitter(
+            {
+                "out_dir": temp_dir,
+                "batch_size": 2,
+                "emit_paths": [("bulk",)],
+            }
+        )
+        assert emitter.emit_prefixes == {"bulk"}
+
+        emitter.emit(self._config_emit())
+        for _ in range(2):
+            emitter.emit(
+                self._sim_emit(
+                    bulk=np.array([1, 2]),
+                    listeners__mass__cell_mass=1.0,
+                )
+            )
+        emitter.last_batch_future.result()
+
+        t = pl.read_parquet(
+            os.path.join(temp_dir, "test_exp", "history", "**", "*.pq"),
+            hive_partitioning=True,
+        )
+        assert "bulk" in t.columns
+        assert "listeners__mass__cell_mass" not in t.columns
+
+    def test_emit_paths_multiple_paths(self, temp_dir):
+        """Multiple paths in emit_paths each filter correctly."""
+        emitter = ParquetEmitter(
+            {
+                "out_dir": temp_dir,
+                "batch_size": 2,
+                "emit_paths": [
+                    ("listeners", "mass"),
+                    ("bulk",),
+                ],
+            }
+        )
+        assert emitter.emit_prefixes == {"listeners__mass", "bulk"}
+
+        emitter.emit(self._config_emit())
+        for _ in range(2):
+            emitter.emit(
+                self._sim_emit(
+                    bulk=np.array([1, 2]),
+                    listeners__mass__cell_mass=1.0,
+                    listeners__growth__rate=0.5,
+                )
+            )
+        emitter.last_batch_future.result()
+
+        t = pl.read_parquet(
+            os.path.join(temp_dir, "test_exp", "history", "**", "*.pq"),
+            hive_partitioning=True,
+        )
+        assert "bulk" in t.columns
+        assert "listeners__mass__cell_mass" in t.columns
+        assert "listeners__growth__rate" not in t.columns
+
+    def test_emit_paths_time_always_included(self, temp_dir):
+        """The 'time' field is always included regardless of emit_paths."""
+        emitter = ParquetEmitter(
+            {
+                "out_dir": temp_dir,
+                "batch_size": 2,
+                "emit_paths": [("bulk",)],
+            }
+        )
+
+        emitter.emit(self._config_emit())
+        for _ in range(2):
+            emitter.emit(self._sim_emit(time=1.5, bulk=np.array([7, 8])))
+        emitter.last_batch_future.result()
+
+        t = pl.read_parquet(
+            os.path.join(temp_dir, "test_exp", "history", "**", "*.pq"),
+            hive_partitioning=True,
+        )
+        assert "time" in t.columns
+        assert t["time"].to_list() == [1.5, 1.5]
+
+    def test_emit_paths_prefix_does_not_match_sibling(self, temp_dir):
+        """A prefix like 'listeners__mass' must not match 'listeners__mass_extra'."""
+        emitter = ParquetEmitter(
+            {
+                "out_dir": temp_dir,
+                "batch_size": 2,
+                "emit_paths": [("listeners", "mass")],
+            }
+        )
+
+        emitter.emit(self._config_emit())
+        for _ in range(2):
+            emitter.emit(
+                self._sim_emit(
+                    listeners__mass__cell_mass=1.0,
+                    listeners__mass_extra__value=99.0,
+                )
+            )
+        emitter.last_batch_future.result()
+
+        t = pl.read_parquet(
+            os.path.join(temp_dir, "test_exp", "history", "**", "*.pq"),
+            hive_partitioning=True,
+        )
+        assert "listeners__mass__cell_mass" in t.columns
+        assert "listeners__mass_extra__value" not in t.columns
+
+    def test_emit_paths_stores_prefixes_correctly(self, temp_dir):
+        """emit_prefixes are stored as double-underscore joined strings."""
+        emitter = ParquetEmitter(
+            {
+                "out_dir": temp_dir,
+                "emit_paths": [
+                    ("a", "b", "c"),
+                    ("x",),
+                ],
+            }
+        )
+        assert emitter.emit_prefixes == {"a__b__c", "x"}

--- a/ecoli/processes/transcript_elongation.py
+++ b/ecoli/processes/transcript_elongation.py
@@ -604,15 +604,25 @@ def get_mapping_arrays(x, y):
 
 
 def format_data(data, bulk_ids, rna_dtypes, rnap_dtypes, submass_dtypes):
-    # Format unique and bulk data for assertions
-    data["unique"]["RNA"] = [
-        np.array(list(map(tuple, zip(*val))), dtype=rna_dtypes + submass_dtypes)
-        for val in data["unique"]["RNA"]
-    ]
-    data["unique"]["active_RNAP"] = [
-        np.array(list(map(tuple, zip(*val))), dtype=rnap_dtypes + submass_dtypes)
-        for val in data["unique"]["active_RNAP"]
-    ]
+    # data["unique"]["RNA"] is {field: [arr_t0, arr_t1, ...], ...}
+    # Convert to [structured_arr_t0, structured_arr_t1, ...]
+    def timeseries_to_structured(field_timeseries, dtype):
+        n_timesteps = len(next(iter(field_timeseries.values())))
+        result = []
+        for t in range(n_timesteps):
+            vals = {field: arrays[t] for field, arrays in field_timeseries.items()}
+            arr = np.empty(len(next(iter(vals.values()))), dtype=dtype)
+            for name in arr.dtype.names:
+                arr[name] = vals[name]
+            result.append(arr)
+        return result
+
+    data["unique"]["RNA"] = timeseries_to_structured(
+        data["unique"]["RNA"], np.dtype(rna_dtypes + submass_dtypes)
+    )
+    data["unique"]["active_RNAP"] = timeseries_to_structured(
+        data["unique"]["active_RNAP"], np.dtype(rnap_dtypes + submass_dtypes)
+    )
     bulk_timeseries = np.array(data["bulk"])
     data["bulk"] = {
         bulk_id: bulk_timeseries[:, i] for i, bulk_id in enumerate(bulk_ids)

--- a/ecoli/processes/transcript_elongation.py
+++ b/ecoli/processes/transcript_elongation.py
@@ -604,8 +604,10 @@ def get_mapping_arrays(x, y):
 
 
 def format_data(data, bulk_ids, rna_dtypes, rnap_dtypes, submass_dtypes):
-    # data["unique"]["RNA"] is {field: [arr_t0, arr_t1, ...], ...}
-    # Convert to [structured_arr_t0, structured_arr_t1, ...]
+    # Emits for each field is collated across timesteps by the vivarium-core
+    # function vivarium.core.emitter.Emitter.get_timeseries()
+    # As such, data["unique"]["RNA"] is {field: [arr_t0, arr_t1, ...], ...}
+    # We want to convert to [structured_arr_t0, structured_arr_t1, ...]
     def timeseries_to_structured(field_timeseries, dtype):
         n_timesteps = len(next(iter(field_timeseries.values())))
         result = []


### PR DESCRIPTION
This PR fixes the `emit_paths` configuration option, which is currently non-functional when using the Parquet emitter through `ecoli_master_sim.py` (the default simulation interface). Now, users can manually specify simulation paths to selectively emit.

Additionally, this PR changes the unique molecule serializer to emit a mapping from field names to arrays with consistent dimensionality (supported by Parquet emitter) instead of a list of arrays with varying dimensionality (not supported by Parquet emitter).

Finally, this PR documents the core reason why the `log_updates` option is not supported by the Parquet emitter.