### PR TITLE
Document limitation with N-D array emits

### DIFF
--- a/doc/output.rst
+++ b/doc/output.rst
@@ -183,7 +183,9 @@ of integers where some entries are empty lists).
   If you choose to emit multi-dimensional listeners, they must have a default value
   defined through a ports schema that is the same shape as the emitted values at
   all time steps. For example, if emitted values are 2-D arrays of shape (3, 4),
-  the default value must also be a 2-D array of shape (3, 4).
+  the default value must also be a 2-D array of shape (3, 4). This is because
+  the Parquet emitter pre-allocates its NumPy buffer from the default's shape
+  and any later mismatch falls to the Polars path, which doesn't handle N-D arrays.
 
 The Parquet emitter saves the serialized tabular data to two Hive-partitioned
 directories in the output folder (``out_dir`` or ``out_uri`` option under

--- a/doc/output.rst
+++ b/doc/output.rst
@@ -180,6 +180,10 @@ of integers where some entries are empty lists).
   The Parquet emitter is poorly suited for storing large listeners that have more
   than a single dimension per time step. We recommend splitting these listeners up
   if possible, especially if you plan to read specific indices along those dimensions.
+  If you choose to emit multi-dimensional listeners, they must have a default value
+  defined through a ports schema that is the same shape as the emitted values at
+  all time steps. For example, if emitted values are 2-D arrays of shape (3, 4),
+  the default value must also be a 2-D array of shape (3, 4).
 
 The Parquet emitter saves the serialized tabular data to two Hive-partitioned
 directories in the output folder (``out_dir`` or ``out_uri`` option under

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -1117,8 +1117,8 @@ class ParquetEmitter(Emitter):
                                 "with that expected shape. Otherwise, convert "
                                 "the value to Python lists using tolist() or "
                                 "flatten it to 1-D and emit the shape separately."
-                            )
-                    raise e
+                            ) from e
+                    raise
                 # Ensure type consistency
                 curr_type = self.pl_types.setdefault(k, pl.Null)
                 if v.dtype != curr_type:

--- a/ecoli/library/parquet_emitter.py
+++ b/ecoli/library/parquet_emitter.py
@@ -1103,7 +1103,22 @@ class ParquetEmitter(Emitter):
                                 :emit_idx
                             ].tolist() + [None] * (self.batch_size - emit_idx)
                 # Fall back Polars serialization
-                v = pl.Series([v])
+                try:
+                    v = pl.Series([v])
+                except ValueError as e:
+                    if isinstance(v, np.ndarray):
+                        if v.ndim > 1:
+                            raise ValueError(
+                                f"Field {k} is a NumPy array with "
+                                "more than 1 dimension, which cannot be "
+                                "serialized using the fallback Polars logic. "
+                                "If this field has a consistent shape, update "
+                                "the ports schema to define a default value "
+                                "with that expected shape. Otherwise, convert "
+                                "the value to Python lists using tolist() or "
+                                "flatten it to 1-D and emit the shape separately."
+                            )
+                    raise e
                 # Ensure type consistency
                 curr_type = self.pl_types.setdefault(k, pl.Null)
                 if v.dtype != curr_type:

--- a/ecoli/library/test_parquet_emitter.py
+++ b/ecoli/library/test_parquet_emitter.py
@@ -1391,7 +1391,7 @@ class TestParquetEmitterEdgeCases:
         }
         with pytest.raises(
             ValueError,
-            match=re.escape("cannot parse numpy data type dtype('O')"),
+            match=re.escape("more than 1 dimension"),
         ):
             emitter.emit(sim_data7)
 

--- a/ecoli/processes/metabolism_redux.py
+++ b/ecoli/processes/metabolism_redux.py
@@ -395,7 +395,9 @@ class MetabolismRedux(Step):
                         "estimated_exchange_dmdt": {},
                         "estimated_intermediate_dmdt": [],
                         "target_kinetic_fluxes": [],
-                        "target_kinetic_bounds": [],
+                        "target_kinetic_bounds": np.zeros(
+                            (len(self.kinetic_constraint_reactions), 2), dtype=int
+                        ),
                         "reaction_catalyst_counts": [],
                         "maintenance_target": 0,
                     }


### PR DESCRIPTION
The Parquet emitter does not support variable-shape multidimensional NumPy arrays. Such arrays must either be converted into nested Python lists (`.tolist()`) or flattened to 1-D with the array shape emitted separately.

This PR also fixes the `target_kinetic_bounds` listener, which is a multidimensional array but with a consistent shape. For fixed-shape N-D arrays, the Parquet emitter simply needs to know the shape up front, which is determined from the default value provided in the ports schema.