### PR TITLE
Update base container image to uv 0.11.14

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -19,7 +19,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
-          version: "0.11.8"
+          version: "0.11.14"
       - name: Install Pandoc
         run: sudo apt-get install pandoc
       - name: Install model

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
-          version: "0.11.8"
+          version: "0.11.14"
       - name: Install Pandoc
         run: sudo apt-get install pandoc
       - name: Install model

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -28,7 +28,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
-          version: "0.11.8"
+          version: "0.11.14"
 
       - name: Install pip-audit and packaging
         run: |

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -41,7 +41,7 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.11.8"
+        version: "0.11.14"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen
     - name: Test ParCa reproducibility
@@ -89,7 +89,7 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.11.8"
+        version: "0.11.14"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen
     - name: Install nextflow edge

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,7 +27,7 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.11.8"
+        version: "0.11.14"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Cache ParCa simulation data
@@ -58,7 +58,7 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.11.8"
+        version: "0.11.14"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Mypy
@@ -74,7 +74,7 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
-        version: "0.11.8"
+        version: "0.11.14"
     - name: Install model
       run: USE_CYTHON=1 uv sync --frozen --extra dev
     - name: Ruff

--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -53,6 +53,75 @@ We would appreciate if you added tests as part of your pull requests.
 This could be as simple as a Python function with the ``test_`` prefix that ensures
 the code added or modified in your PR works as intended using a few test cases.
 
+Updating GitHub Actions
+=======================
+
+.. note::
+  Usually, there should be no need to update GitHub Actions workflows unless a vulnerability
+  is found or a new version of an action is released that has important bug fixes or features.
+  The vEcoli repository has CodeQL set up to automatically scan for vulnerabilities in GitHub
+  Actions workflows and will alert maintainers if any are found. 
+
+For security purposes, all GitHub Actions steps are pinned to a specific version of the action
+using a commit hash. To update an action, navigate to the GitHub repository for the action (search
+by name), click on "Releases" in the right sidebar, and find the latest release. Click on the release
+and copy the commit hash for that release. Then, replace the old commit hash with the new one in the
+relevant workflow file(s) in ``.github/workflows`` and push the change to GitHub.
+
+Python Vulnerability Scanning
+=============================
+
+The ``.github/workflows/pip_audit.yml`` workflow runs the ``pip-audit`` tool to check for known
+vulnerabilities in the Python dependencies of vEcoli. This workflow is scheduled to run daily,
+and also runs on PRs and changes to ``master``. When vulnerabilities are detected that have
+available fixes, the workflow will automatically open a PR to update the relevant dependencies.
+
+The body of the PR will contain information about vulnerabilities found, including the severity
+and CVE identifiers, as well as the fixed versions of the affected dependencies. Since the PR
+is opened by a bot, the required CI checks will not run until a user manually closes and reopens
+the PR. If new vulnerabilities are detected after the PR is opened, the pip-audit workflow will
+update the PR with the new information and available fixes.
+
+Carefully review the vulnerability information in the PR body and ensure the affected dependencies
+are correctly updated to fixed versions. Once all checks are passing, the PR can be merged.
+
+Container Vulnerability Scanning
+================================
+
+The ``.github/workflows/docker_security.yml`` workflow builds a Docker image using
+``runscripts/container/Dockerfile`` and scans it for vulnerabilities using Docker Scout.
+This workflow is scheduled to run daily, and also runs on PRs and changes to ``master``.
+
+When run on PRs from branches in the main vEcoli repository, a comment will be added to the
+PR with a summary of the vulnerabilities found, including the severity and CVE identifiers as well
+as available fixes. We strongly recommend that you review this information and update the base
+container image (see below) if any vulnerabilities are found with available fixes.
+
+The daily runs on the ``master`` branch will generate a report that can be viewed by clicking on the
+"Actions" tab, "Docker Build and Security Scan" in the left sidebar, then a particular workflow run.
+Alternatively, members of the lab can view all detected vulnerabilities by clicking on the "Security
+and quality" tab, then "Code scanning" in the left sidebar.
+
+.. warning::
+  PRs from forks will not be able to run the Docker build and security scan workflow because it requires
+  access to repository secrets (DockerHub credentials) not accessible to forks. Therefore, it is especially
+  important to be wary of Docker image changes or dependency changes in PRs from forks, and to check the
+  results of the daily runs on master for any vulnerabilities with available fixes.
+
+Update Container Base Image
+============================
+
+To update the base container image, navigate to ``https://github.com/astral-sh/uv/pkgs/container/uv`` and
+click to "View all tagged versions". Find the latest image tagged with ``debian-slim``, click the three
+dots next to "Digest", and copy the digest. Then, modify the ``FROM`` line in ``runscripts/container/Dockerfile``
+and the ``From:`` line in ``runscripts/container/Singularity`` to use the new digest.
+
+Take note of the version of uv used in the new image (should be included in at least one of the other tags
+for the image). Update the version of uv used in the GitHub Actions workflows in ``.github/workflows`` (can
+find and replace the old version with the new version) to ensure consistency across the repository. Finally,
+commit and push these changes to a new branch and open a PR to merge them.
+
+
 Merge Queue
 ===========
 

--- a/doc/ci.rst
+++ b/doc/ci.rst
@@ -73,7 +73,7 @@ Python Vulnerability Scanning
 
 The ``.github/workflows/pip_audit.yml`` workflow runs the ``pip-audit`` tool to check for known
 vulnerabilities in the Python dependencies of vEcoli. This workflow is scheduled to run daily,
-and also runs on PRs and changes to ``master``. When vulnerabilities are detected that have
+and also on changes to ``master``. When vulnerabilities are detected that have
 available fixes, the workflow will automatically open a PR to update the relevant dependencies.
 
 The body of the PR will contain information about vulnerabilities found, including the severity

--- a/runscripts/container/Dockerfile
+++ b/runscripts/container/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Use runscripts/container/build-image.sh to build.
 
-FROM ghcr.io/astral-sh/uv@sha256:de254da1c9abae7926e5cf29a6ab4a5ea65d3290682d88aa416445fa3de681bf
+FROM ghcr.io/astral-sh/uv@sha256:2702577da32d9c3d55c8073e07d4476cd7402c085efbf71921104548c851d96a
 
 LABEL application="Whole Cell Model of Escherichia coli" \
     email="wholecellteam@lists.stanford.edu" \

--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: ghcr.io/astral-sh/uv@sha256:de254da1c9abae7926e5cf29a6ab4a5ea65d3290682d88aa416445fa3de681bf
+From: ghcr.io/astral-sh/uv@sha256:2702577da32d9c3d55c8073e07d4476cd7402c085efbf71921104548c851d96a
 
 # Refer to Dockerfile for comments about build process. Apptainer does not
 # support layer caching which results in a much less interesting build file.


### PR DESCRIPTION
Should fix GHSA-82j2-j2ch-gfr8.

Also adds documentation for the security-related CI tests and how to update the base container image.