### PR TITLE
Honor lower-level analysis filters

### DIFF
--- a/ecoli/processes/transcript_elongation.py
+++ b/ecoli/processes/transcript_elongation.py
@@ -62,27 +62,28 @@ class TranscriptElongation(PartitionedProcess):
 
     defaults:
         - rnaPolymeraseElongationRateDict (dict): Array with elongation rate
-            set points for different media environments.
+          set points for different media environments.
         - rnaIds (array[str]) : array of names for each TU
         - rnaLengths (array[int]) : array of lengths for each TU
-            (in nucleotides?)
+          (in nucleotides?)
         - rnaSequences (2D array[int]) : Array with the nucleotide sequences
-            of each TU. This is in the form of a 2D array where each row is a
-            TU, and each column is a position in the TU's sequence. Nucleotides
-            are stored as an index {0, 1, 2, 3}, and the row is padded with
-            -1's on the right to indicate where the sequence ends.
+          of each TU. This is in the form of a 2D array where each row is a
+          TU, and each column is a position in the TU's sequence. Nucleotides
+          are stored as an index {0, 1, 2, 3}, and the row is padded with
+          -1's on the right to indicate where the sequence ends.
         - ntWeights (array[float]): Array of nucleotide weights
-        - endWeight (array[float]): ???,
+        - endWeight (array[float]): Additional mass added when an RNA
+          transcript is completed (termination/end-group mass adjustment),
         - replichore_lengths (array[int]): lengths of replichores
-            (in nucleotides?),
+          (in nucleotides?),
         - is_mRNA (array[bool]): Mask for mRNAs
         - ppi (str): ID of PPI
         - inactive_RNAP (str): ID of inactive RNAP
         - ntp_ids list[str]: IDs of ntp's (A, C, G, U)
         - variable_elongation (bool): Whether to use variable elongation.
-                                      False by default.
+          False by default.
         - make_elongation_rates: Function to make elongation rates, of the
-            form: lambda random, rates, timestep, variable: rates
+          form: lambda random, rates, timestep, variable: rates
     """
 
     name = NAME
@@ -151,7 +152,6 @@ class TranscriptElongation(PartitionedProcess):
         self.make_elongation_rates = self.parameters["make_elongation_rates"]
 
         self.polymerized_ntps = self.parameters["polymerized_ntps"]
-        self.charged_trna_names = self.parameters["charged_trnas"]
 
         # Attenuation
         self.trna_attenuation = self.parameters["trna_attenuation"]

--- a/runscripts/analysis.py
+++ b/runscripts/analysis.py
@@ -120,7 +120,7 @@ def make_sim_data_dict(exp_id: str, variants: list[int], sim_data_path: list[str
     return {exp_id: dict(zip(variants, sim_data_path))}
 
 
-def build_duckdb_filter(config: dict) -> str:
+def build_duckdb_filter(config: dict) -> list[tuple[str, str]]:
     """
     Build a DuckDB WHERE clause from config filters.
 
@@ -128,9 +128,11 @@ def build_duckdb_filter(config: dict) -> str:
         config: Configuration dictionary with filter values
 
     Returns:
-        DuckDB WHERE clause string
+        List of (column_name, condition_string) tuples representing each
+        filter condition. Join the condition strings with " AND " to form
+        a complete WHERE clause.
     """
-    duckdb_filter = []
+    duckdb_filter: list[tuple[str, str]] = []
     last_analysis_level = -1
     filter_types = list(FILTERS.keys())
 
@@ -166,20 +168,28 @@ def build_duckdb_filter(config: dict) -> str:
             if len(config[data_filter]) > 1:
                 if data_type is str:
                     filter_values = "', '".join(str(i) for i in config[data_filter])
-                    duckdb_filter.append(f"{data_filter} IN ('{filter_values}')")
+                    duckdb_filter.append(
+                        (data_filter, f"{data_filter} IN ('{filter_values}')")
+                    )
                 else:
                     filter_values = ", ".join(str(i) for i in config[data_filter])
-                    duckdb_filter.append(f"{data_filter} IN ({filter_values})")
+                    duckdb_filter.append(
+                        (data_filter, f"{data_filter} IN ({filter_values})")
+                    )
             else:
                 if data_type is str:
                     quoted_val = str(config[data_filter][0])
-                    duckdb_filter.append(f"{data_filter} = '{quoted_val}'")
+                    duckdb_filter.append(
+                        (data_filter, f"{data_filter} = '{quoted_val}'")
+                    )
                 else:
-                    duckdb_filter.append(f"{data_filter} = {config[data_filter][0]}")
+                    duckdb_filter.append(
+                        (data_filter, f"{data_filter} = {config[data_filter][0]}")
+                    )
 
             last_analysis_level = current_analysis_level
 
-    return " AND ".join(duckdb_filter)
+    return duckdb_filter
 
 
 def load_variant_metadata(
@@ -290,7 +300,7 @@ def filter_variant_dicts(
 
 def build_query_strings(
     analysis_type: str,
-    duckdb_filter: str,
+    duckdb_filter: list[tuple[str, str]],
     config_sql: str,
     history_sql: str,
     success_sql: str,
@@ -302,7 +312,8 @@ def build_query_strings(
 
     Args:
         analysis_type: Type of analysis (e.g., "multivariant", "single")
-        duckdb_filter: DuckDB WHERE clause
+        duckdb_filter: List of (column_name, condition_string) tuples from
+            build_duckdb_filter
         config_sql: SQL query for config data
         history_sql: SQL query for history data
         success_sql: SQL query for success data
@@ -314,6 +325,7 @@ def build_query_strings(
         (history_query, config_query, success_query, output_dir, variant_set)
     """
     id_cols = ANALYSIS_TYPES[analysis_type]
+    duckdb_filter_str = " AND ".join(cond for _, cond in duckdb_filter)
     query_strings = {}
 
     if len(id_cols) > 0:
@@ -326,7 +338,7 @@ def build_query_strings(
         select_cols = ", ".join(cols_to_select)
 
         data_ids_with_variants = conn.sql(
-            f"SELECT DISTINCT {select_cols} FROM ({config_sql}) WHERE {duckdb_filter}"
+            f"SELECT DISTINCT {select_cols} FROM ({config_sql}) WHERE {duckdb_filter_str}"
         ).fetchall()
 
         # Group by the id_cols to collect variants for each subset
@@ -341,13 +353,9 @@ def build_query_strings(
 
         # Extract lower-level filter conditions (columns not in id_cols) so
         # they are still applied in the per-subset SQL passed to analysis scripts.
-        lower_level_parts = []
-        if duckdb_filter:
-            for condition in duckdb_filter.split(" AND "):
-                col_name = condition.strip().split(" ")[0]
-                if col_name not in id_cols:
-                    lower_level_parts.append(condition.strip())
-        lower_level_filter = " AND ".join(lower_level_parts)
+        lower_level_filter = " AND ".join(
+            cond for col, cond in duckdb_filter if col not in id_cols
+        )
 
         for data_id, variant_set in id_to_variants.items():
             data_filters = []
@@ -378,13 +386,13 @@ def build_query_strings(
         # For analysis types with no id_cols, query all variants matching the filter
         all_variants = conn.sql(
             f"SELECT DISTINCT experiment_id, variant"
-            f" FROM ({config_sql}) WHERE {duckdb_filter}"
+            f" FROM ({config_sql}) WHERE {duckdb_filter_str}"
         ).fetchall()
         variant_set = set(all_variants)
-        query_strings[duckdb_filter] = (
-            f"SELECT * FROM ({history_sql}) WHERE {duckdb_filter}",
-            f"SELECT * FROM ({config_sql}) WHERE {duckdb_filter}",
-            f"SELECT * FROM ({success_sql}) WHERE {duckdb_filter}",
+        query_strings[duckdb_filter_str] = (
+            f"SELECT * FROM ({history_sql}) WHERE {duckdb_filter_str}",
+            f"SELECT * FROM ({config_sql}) WHERE {duckdb_filter_str}",
+            f"SELECT * FROM ({success_sql}) WHERE {duckdb_filter_str}",
             os.path.abspath(outdir),
             variant_set,
         )
@@ -398,7 +406,7 @@ def run_analysis_loop(
     history_sql: str,
     config_sql: str,
     success_sql: str,
-    duckdb_filter: str,
+    duckdb_filter: list[tuple[str, str]],
     variant_metadata: dict,
     sim_data_dict: dict,
     variant_names: dict,
@@ -412,7 +420,8 @@ def run_analysis_loop(
         history_sql: SQL query for history data
         config_sql: SQL query for config data
         success_sql: SQL query for success data
-        duckdb_filter: DuckDB WHERE clause for filtering data
+        duckdb_filter: List of (column_name, condition_string) tuples from
+            build_duckdb_filter
         variant_metadata: Variant metadata dictionary
         sim_data_dict: Sim data dictionary
         variant_names: Variant names dictionary

--- a/runscripts/analysis.py
+++ b/runscripts/analysis.py
@@ -339,6 +339,16 @@ def build_query_strings(
             var_id = row[var_id_idx]
             id_to_variants[data_id].add((exp_id, var_id))
 
+        # Extract lower-level filter conditions (columns not in id_cols) so
+        # they are still applied in the per-subset SQL passed to analysis scripts.
+        lower_level_parts = []
+        if duckdb_filter:
+            for condition in duckdb_filter.split(" AND "):
+                col_name = condition.strip().split(" ")[0]
+                if col_name not in id_cols:
+                    lower_level_parts.append(condition.strip())
+        lower_level_filter = " AND ".join(lower_level_parts)
+
         for data_id, variant_set in id_to_variants.items():
             data_filters = []
             curr_outdir = os.path.abspath(outdir)
@@ -350,10 +360,15 @@ def build_query_strings(
                 data_filters.append(f"{col}={col_val}")
             os.makedirs(curr_outdir, exist_ok=True)
             data_filters = " AND ".join(data_filters)
+            full_filter = (
+                f"{data_filters} AND {lower_level_filter}"
+                if lower_level_filter
+                else data_filters
+            )
             query_strings[data_filters] = (
-                f"SELECT * FROM ({history_sql}) WHERE {data_filters}",
-                f"SELECT * FROM ({config_sql}) WHERE {data_filters}",
-                f"SELECT * FROM ({success_sql}) WHERE {data_filters}",
+                f"SELECT * FROM ({history_sql}) WHERE {full_filter}",
+                f"SELECT * FROM ({config_sql}) WHERE {full_filter}",
+                f"SELECT * FROM ({success_sql}) WHERE {full_filter}",
                 curr_outdir,
                 variant_set,
             )

--- a/runscripts/container/Singularity
+++ b/runscripts/container/Singularity
@@ -32,7 +32,9 @@ From: ghcr.io/astral-sh/uv@sha256:2702577da32d9c3d55c8073e07d4476cd7402c085efbf7
         tar -xf /repo.tar -C /vEcoli
         rm /repo.tar
     fi
-    apt-get update && apt-get install -y gcc procps nano curl g++
+    # No need for ca-certificates and unzip since not installing AWS CLI
+    apt-get update && apt-get install -y gcc procps nano curl g++ \
+        && apt-get clean && rm -rf /var/lib/apt/lists/*
     cd /vEcoli
     # Source shared uv environment variables
     . /vEcoli/singularity-env.sh

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -26,7 +26,8 @@ params {
             proc.waitFor()
             return proc.text.trim()
         } catch (Exception e) {
-            return ''
+            System.err.println("WARNING: Failed to read gcloud compute/region: ${e.message}")
+            return 'GCLOUD_CONFIG_ERROR'
         }
     }()
     google_project = {
@@ -35,7 +36,8 @@ params {
             proc.waitFor()
             return proc.text.trim()
         } catch (Exception e) {
-            return ''
+            System.err.println("WARNING: Failed to read gcloud project: ${e.message}")
+            return 'GCLOUD_CONFIG_ERROR'
         }
     }()
 }
@@ -47,46 +49,43 @@ trace.sep = ','
 trace.fields = 'name,native_id,status,submit,start,complete,duration,realtime,exit,%cpu,%mem,rss,peak_rss,error_action,attempt,cpu_model,workdir'
 trace.file = "trace--${params.experimentId}--" + new java.text.SimpleDateFormat("yyyy-MM-dd--HH-mm-ss").format(new Date()) + ".csv"
 
+def scaledMemory = { task, baseMem ->
+    if ( task.exitStatus == 137 ) {
+        1.GB * baseMem * task.attempt
+    } else {
+        // Do not scale further if mem was not issue last time
+        // Using task.attempts - 1 is inexact if a process experiences
+        // multiple failures. For example, a process can fail due to OOM
+        // (137), fail its first retry due to pre-emption (50001), then
+        // fail its second retry due to OOM (137). On its third attempt, it
+        // will get memory equivalent to if it had failed from OOM three
+        // times instead of twice. I feel it is better to overallocate than
+        // underallocate. Additionally, if users are seeing retries due to
+        // resource underallocation, they should just bump the base resource
+        // requests in their config files.
+        1.GB * baseMem * Math.max(1, task.attempt - 1)
+    }
+}
+
+def scaleTimeForRetry = { task, baseTime ->
+    if ( task.exitStatus == 140 ) {
+        1.h * baseTime * task.attempt
+    } else {
+        // Do not scale further if time was not issue last time
+        1.h * baseTime * Math.max(1, task.attempt - 1)
+    }
+}
+
 process {
     withLabel: parca {
         cpus = params.parca_cpus
-        memory = {
-            if ( task.exitStatus == 137 ) {
-                1.GB * params.parca_mem * task.attempt
-            } else {
-                // Do not scale further if mem was not issue last time
-                // Using task.attempts - 1 is inexact if a process experiences
-                // multiple failures. For example, a process can fail due to OOM
-                // (137), fail its first retry due to pre-emption (50001), then
-                // fail its second retry due to OOM (137). On its third attempt, it
-                // will get memory equivalent to if it had failed from OOM three
-                // times instead of twice. I feel it is better to overallocate than
-                // underallocate. Additionally, if users are seeing retries due to
-                // resource underallocation, they should just bump the base resource
-                // requests in their config files.
-                1.GB * params.parca_mem * Math.max(1, task.attempt - 1)
-            }
-        }
+        memory = { scaledMemory(task, params.parca_mem) }
     }
     withLabel: analysis {
         cpus = params.analysis_cpus
-        memory = {
-            if ( task.exitStatus == 137 ) {
-                1.GB * params.analysis_mem * task.attempt
-            } else {
-                // Do not scale further if mem was not issue last time
-                1.GB * params.analysis_mem * Math.max(1, task.attempt - 1)
-            }
-        }
+        memory = { scaledMemory(task, params.analysis_mem) }
     }
-    memory = {
-        if ( task.exitStatus == 137 ) {
-            1.GB * params.sim_mem * task.attempt
-        } else {
-            // Do not scale further if mem was not issue last time
-            1.GB * params.sim_mem * Math.max(1, task.attempt - 1)
-        }
-    }
+    memory = { scaledMemory(task, params.sim_mem) }
     maxRetries = 3
     cpus = params.sim_cpus
 }
@@ -156,54 +155,20 @@ profiles {
             // required to make time directives only apply to SLURM profiles
             withLabel: parca {
                 cpus = params.parca_cpus
-                memory = {
-                    if ( task.exitStatus == 137 ) {
-                        1.GB * params.parca_mem * task.attempt
-                    } else {
-                        1.GB * params.parca_mem * Math.max(1, task.attempt - 1)
-                    }
-                }
-                time = {
-                    if ( task.exitStatus == 140 ) {
-                        1.h * params.parca_time * task.attempt
-                    } else {
-                        // Do not scale further if time was not issue last time
-                        1.h * params.parca_time * Math.max(1, task.attempt - 1)
-                    }
-                }
+                memory = { scaledMemory(task, params.parca_mem) }
+                time = { scaleTimeForRetry(task, params.parca_time) }
             }
             withLabel: analysis {
                 cpus = params.analysis_cpus
-                memory = {
-                    if ( task.exitStatus == 137 ) {
-                        1.GB * params.analysis_mem * task.attempt
-                    } else {
-                        // Do not scale further if mem was not issue last time
-                        1.GB * params.analysis_mem * Math.max(1, task.attempt - 1)
-                    }
-                }
-                time = {
-                    if ( task.exitStatus == 140 ) {
-                        1.h * params.analysis_time * task.attempt
-                    } else {
-                        // Do not scale further if time was not issue last time
-                        1.h * params.analysis_time * Math.max(1, task.attempt - 1)
-                    }
-                }
+                memory = { scaledMemory(task, params.analysis_mem) }
+                time = { scaleTimeForRetry(task, params.analysis_time) }
             }
             container = params.container_image
             containerOptions = "-B ${params.publishDir}:${params.publishDir} -B ${launchDir}:${launchDir} ${params.slurm_env}"
             queue = params.queue
             clusterOptions = params.cluster_options
             executor = 'slurm'
-            time = {
-                if ( task.exitStatus == 140 ) {
-                    1.h * params.sim_time * task.attempt
-                } else {
-                    // Do not scale further if time was not issue last time
-                    1.h * params.sim_time * Math.max(1, task.attempt - 1)
-                }
-            }
+            time = { scaleTimeForRetry(task, params.sim_time) }
             errorStrategy = {
                 // Codes: 137 (OOM), 140 (SLURM job limits), 143 (SLURM preemption)
                 // Default value for exitStatus is max integer value, this
@@ -236,24 +201,11 @@ profiles {
             withLabel: parca {
                 // Nextflow does not merge withLabel directives so must repeat
                 cpus = params.parca_cpus
-                memory = {
-                    if ( task.exitStatus == 137 ) {
-                        1.GB * params.parca_mem * task.attempt
-                    } else {
-                        1.GB * params.parca_mem * Math.max(1, task.attempt - 1)
-                    }
-                }
+                memory = { scaledMemory(task, params.parca_mem) }
                 executor = 'slurm'
                 queue = params.queue
                 clusterOptions = params.cluster_options
-                time = {
-                    if ( task.exitStatus == 140 ) {
-                        1.h * params.parca_time * task.attempt
-                    } else {
-                        // Do not scale further if time was not issue last time
-                        1.h * params.parca_time * Math.max(1, task.attempt - 1)
-                    }
-                }
+                time = { scaleTimeForRetry(task, params.parca_time) }
             }
             // Creating variants happens before the HyperQueue workers
             // are allocated and requires a separate SLURM job
@@ -266,22 +218,8 @@ profiles {
             // stalling sims and allow custom resource requests
             withLabel: analysis {
                 cpus = params.analysis_cpus
-                memory = {
-                    if ( task.exitStatus == 137 ) {
-                        1.GB * params.analysis_mem * task.attempt
-                    } else {
-                        // Do not scale further if mem was not issue last time
-                        1.GB * params.analysis_mem * Math.max(1, task.attempt - 1)
-                    }
-                }
-                time = {
-                    if ( task.exitStatus == 140 ) {
-                        1.h * params.analysis_time * task.attempt
-                    } else {
-                        // Do not scale further if time was not issue last time
-                        1.h * params.analysis_time * Math.max(1, task.attempt - 1)
-                    }
-                }
+                memory = { scaledMemory(task, params.analysis_mem) }
+                time = { scaleTimeForRetry(task, params.analysis_time) }
                 executor = 'slurm'
                 queue = params.queue
                 clusterOptions = params.cluster_options
@@ -291,14 +229,7 @@ profiles {
             containerOptions = "-B ${params.publishDir}:${params.publishDir} -B ${launchDir}:${launchDir} ${params.slurm_env}"
             // Use Nextflow's retry logic instead of HyperQueue's built-in logic
             clusterOptions = '--crash-limit=1'
-            time = {
-                if ( task.exitStatus == 140 ) {
-                    1.h * params.sim_time * task.attempt
-                } else {
-                    // Do not scale further if time was not issue last time
-                    1.h * params.sim_time * Math.max(1, task.attempt - 1)
-                }
-            }
+            time = { scaleTimeForRetry(task, params.sim_time) }
             errorStrategy = {
                 ((task.exitStatus in [137, 140, 143, Integer.MAX_VALUE])
                 && (task.attempt <= task.maxRetries)) ? 'retry' : 'ignore'

--- a/runscripts/nextflow/config.template
+++ b/runscripts/nextflow/config.template
@@ -26,7 +26,7 @@ params {
             proc.waitFor()
             return proc.text.trim()
         } catch (Exception e) {
-            System.err.println("WARNING: Failed to read gcloud compute/region: ${e.message}")
+            System.err.println("WARNING: Failed to read gcloud compute/region. Ignore if not running on GCP: ${e.message}")
             return 'GCLOUD_CONFIG_ERROR'
         }
     }()
@@ -36,7 +36,7 @@ params {
             proc.waitFor()
             return proc.text.trim()
         } catch (Exception e) {
-            System.err.println("WARNING: Failed to read gcloud project: ${e.message}")
+            System.err.println("WARNING: Failed to read gcloud project. Ignore if not running on GCP: ${e.message}")
             return 'GCLOUD_CONFIG_ERROR'
         }
     }()

--- a/runscripts/test_analysis_comprehensive.py
+++ b/runscripts/test_analysis_comprehensive.py
@@ -617,6 +617,88 @@ class TestBuildQueryStrings:
         assert isinstance(variant_set, set)
         assert ("exp1", 0) in variant_set
 
+    def test_lower_level_filter_included_in_sql(self, tmp_path):
+        """Lower-level filters (columns below id_cols) must appear in the SQL
+        strings passed to analysis scripts, not just in the discovery query."""
+        # multigeneration id_cols = ["experiment_id", "variant", "lineage_seed"]
+        # generation is one level below and must survive into the per-subset SQL.
+        conn = MockConnection([("exp1", 0, 42)])
+        analysis_type = "multigeneration"
+        duckdb_filter = "experiment_id = 'exp1' AND variant = 0 AND lineage_seed = 42 AND generation = 5"
+
+        query_strings = build_query_strings(
+            analysis_type,
+            duckdb_filter,
+            "SELECT * FROM config",
+            "SELECT * FROM history",
+            "SELECT * FROM success",
+            str(tmp_path),
+            conn,
+        )
+
+        assert len(query_strings) == 1
+        history_q, config_q, success_q, _, _ = next(iter(query_strings.values()))
+        assert "generation = 5" in history_q
+        assert "generation = 5" in config_q
+        assert "generation = 5" in success_q
+
+    def test_no_lower_level_filters_leaves_sql_unchanged(self, tmp_path):
+        """When all duckdb_filter conditions are for id_cols, the per-subset SQL
+        must not gain any extra filter clauses."""
+        conn = MockConnection([("exp1", 0, 42)])
+        analysis_type = "multigeneration"
+        # All conditions are for id_cols — nothing lower-level.
+        duckdb_filter = "experiment_id = 'exp1' AND variant = 0 AND lineage_seed = 42"
+
+        query_strings = build_query_strings(
+            analysis_type,
+            duckdb_filter,
+            "SELECT * FROM config",
+            "SELECT * FROM history",
+            "SELECT * FROM success",
+            str(tmp_path),
+            conn,
+        )
+
+        history_q, config_q, success_q, _, _ = next(iter(query_strings.values()))
+        # id_col specific values must be present
+        assert "experiment_id='exp1'" in history_q
+        assert "variant=0" in history_q
+        assert "lineage_seed=42" in history_q
+        # No unexpected lower-level columns
+        assert "generation" not in history_q
+        assert "agent_id" not in history_q
+
+    def test_multiple_lower_level_filters_all_included(self, tmp_path):
+        """All lower-level filter conditions must appear in every SQL string."""
+        # multiseed id_cols = ["experiment_id", "variant"]
+        # generation and agent_id are both lower-level for this analysis type.
+        conn = MockConnection([("exp1", 0)])
+        analysis_type = "multiseed"
+        duckdb_filter = (
+            "experiment_id = 'exp1' AND variant = 0"
+            " AND generation = 5 AND agent_id = 'agent_001'"
+        )
+
+        query_strings = build_query_strings(
+            analysis_type,
+            duckdb_filter,
+            "SELECT * FROM config",
+            "SELECT * FROM history",
+            "SELECT * FROM success",
+            str(tmp_path),
+            conn,
+        )
+
+        assert len(query_strings) == 1
+        history_q, config_q, success_q, _, _ = next(iter(query_strings.values()))
+        for sql in (history_q, config_q, success_q):
+            assert "generation = 5" in sql
+            assert "agent_id = 'agent_001'" in sql
+            # id_col values must still be pinned
+            assert "experiment_id='exp1'" in sql
+            assert "variant=0" in sql
+
 
 class TestIntegration:
     """Integration tests that test multiple functions together"""

--- a/runscripts/test_analysis_comprehensive.py
+++ b/runscripts/test_analysis_comprehensive.py
@@ -190,14 +190,15 @@ class TestBuildDuckdbFilter:
         """Test building filter with single string value"""
         config = {"experiment_id": ["test_exp"]}
         result = build_duckdb_filter(config)
-        expected = "experiment_id = 'test_exp'"
-        assert result == expected
+        assert result == [("experiment_id", "experiment_id = 'test_exp'")]
 
     def test_multiple_string_filters(self):
         """Test building filter with multiple string values"""
         config = {"experiment_id": ["exp1", "exp2", "exp3"]}
         result = build_duckdb_filter(config)
-        assert "experiment_id IN ('exp1', 'exp2', 'exp3')" == result
+        assert result == [
+            ("experiment_id", "experiment_id IN ('exp1', 'exp2', 'exp3')")
+        ]
 
     def test_single_int_filter(self):
         """Test building filter with single int value"""
@@ -205,7 +206,7 @@ class TestBuildDuckdbFilter:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = build_duckdb_filter(config)
-            assert result == "variant = 5"
+            assert result == [("variant", "variant = 5")]
             assert len(w) == 1
             assert "applicable data for the skipped" in str(w[0].message).lower()
 
@@ -215,7 +216,7 @@ class TestBuildDuckdbFilter:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = build_duckdb_filter(config)
-            assert "variant IN (0, 1, 2)" == result
+            assert result == [("variant", "variant IN (0, 1, 2)")]
             assert len(w) == 1
             assert "applicable data for the skipped" in str(w[0].message).lower()
 
@@ -227,10 +228,10 @@ class TestBuildDuckdbFilter:
             "lineage_seed": [42],
         }
         result = build_duckdb_filter(config)
-        assert "experiment_id = 'test_exp'" in result
-        assert "variant IN (0, 1)" in result
-        assert "lineage_seed = 42" in result
-        assert " AND " in result
+        assert ("experiment_id", "experiment_id = 'test_exp'") in result
+        assert ("variant", "variant IN (0, 1)") in result
+        assert ("lineage_seed", "lineage_seed = 42") in result
+        assert len(result) == 3
 
     def test_range_filter(self):
         """Test that range filters are converted to lists"""
@@ -238,7 +239,7 @@ class TestBuildDuckdbFilter:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = build_duckdb_filter(config)
-            assert "variant IN (0, 1, 2, 3, 4)" == result
+            assert result == [("variant", "variant IN (0, 1, 2, 3, 4)")]
             # Check that variant list was created in config
             assert config["variant"] == [0, 1, 2, 3, 4]
             assert len(w) == 1
@@ -258,7 +259,7 @@ class TestBuildDuckdbFilter:
                 "Range takes precedence" in str(warning.message) for warning in w
             )
 
-        assert "variant IN (0, 1, 2)" == result
+        assert result == [("variant", "variant IN (0, 1, 2)")]
         assert config["variant"] == [0, 1, 2]
 
     def test_skipped_filter_warning(self):
@@ -277,7 +278,7 @@ class TestBuildDuckdbFilter:
         """Test with no filters specified"""
         config = {}
         result = build_duckdb_filter(config)
-        assert result == ""
+        assert result == []
 
     def test_agent_id_string_filter(self):
         """Test agent_id string filtering"""
@@ -287,7 +288,7 @@ class TestBuildDuckdbFilter:
             result = build_duckdb_filter(config)
             assert len(w) == 1
             assert "applicable data for the skipped" in str(w[0].message).lower()
-            assert "agent_id IN ('agent_001', 'agent_002')" == result
+            assert result == [("agent_id", "agent_id IN ('agent_001', 'agent_002')")]
 
 
 class TestLoadVariantMetadata:
@@ -538,7 +539,7 @@ class TestBuildQueryStrings:
         # Create a mock connection that returns test data
         conn = MockConnection([("exp1", 0), ("exp1", 1)])
         analysis_type = "multiseed"  # Has id_cols = ["experiment_id", "variant"]
-        duckdb_filter = "experiment_id = 'exp1'"
+        duckdb_filter = [("experiment_id", "experiment_id = 'exp1'")]
         config_sql = "SELECT * FROM config"
         history_sql = "SELECT * FROM history"
         success_sql = "SELECT * FROM success"
@@ -562,7 +563,7 @@ class TestBuildQueryStrings:
 
         conn = MockConnection([("exp1", 0), ("exp1", 1)])
         analysis_type = "multiexperiment"  # Has id_cols = []
-        duckdb_filter = "experiment_id = 'exp1'"
+        duckdb_filter = [("experiment_id", "experiment_id = 'exp1'")]
         config_sql = "SELECT * FROM config"
         history_sql = "SELECT * FROM history"
         success_sql = "SELECT * FROM success"
@@ -578,16 +579,16 @@ class TestBuildQueryStrings:
             conn,
         )
 
-        # Should have single entry with the base filter
+        # Should have single entry with the joined filter string as key
         assert len(query_strings) == 1
-        assert duckdb_filter in query_strings
+        assert "experiment_id = 'exp1'" in query_strings
 
     def test_query_string_structure(self):
         """Test that query strings have correct structure"""
 
         conn = MockConnection([("exp1", 0)])
         analysis_type = "multiseed"
-        duckdb_filter = "experiment_id = 'exp1'"
+        duckdb_filter = [("experiment_id", "experiment_id = 'exp1'")]
         config_sql = "SELECT * FROM config"
         history_sql = "SELECT * FROM history"
         success_sql = "SELECT * FROM success"
@@ -624,7 +625,12 @@ class TestBuildQueryStrings:
         # generation is one level below and must survive into the per-subset SQL.
         conn = MockConnection([("exp1", 0, 42)])
         analysis_type = "multigeneration"
-        duckdb_filter = "experiment_id = 'exp1' AND variant = 0 AND lineage_seed = 42 AND generation = 5"
+        duckdb_filter = [
+            ("experiment_id", "experiment_id = 'exp1'"),
+            ("variant", "variant = 0"),
+            ("lineage_seed", "lineage_seed = 42"),
+            ("generation", "generation = 5"),
+        ]
 
         query_strings = build_query_strings(
             analysis_type,
@@ -648,7 +654,11 @@ class TestBuildQueryStrings:
         conn = MockConnection([("exp1", 0, 42)])
         analysis_type = "multigeneration"
         # All conditions are for id_cols — nothing lower-level.
-        duckdb_filter = "experiment_id = 'exp1' AND variant = 0 AND lineage_seed = 42"
+        duckdb_filter = [
+            ("experiment_id", "experiment_id = 'exp1'"),
+            ("variant", "variant = 0"),
+            ("lineage_seed", "lineage_seed = 42"),
+        ]
 
         query_strings = build_query_strings(
             analysis_type,
@@ -675,10 +685,12 @@ class TestBuildQueryStrings:
         # generation and agent_id are both lower-level for this analysis type.
         conn = MockConnection([("exp1", 0)])
         analysis_type = "multiseed"
-        duckdb_filter = (
-            "experiment_id = 'exp1' AND variant = 0"
-            " AND generation = 5 AND agent_id = 'agent_001'"
-        )
+        duckdb_filter = [
+            ("experiment_id", "experiment_id = 'exp1'"),
+            ("variant", "variant = 0"),
+            ("generation", "generation = 5"),
+            ("agent_id", "agent_id = 'agent_001'"),
+        ]
 
         query_strings = build_query_strings(
             analysis_type,
@@ -698,6 +710,39 @@ class TestBuildQueryStrings:
             # id_col values must still be pinned
             assert "experiment_id='exp1'" in sql
             assert "variant=0" in sql
+
+    def test_and_in_string_value_does_not_corrupt_lower_level_filter(self, tmp_path):
+        """A string filter value containing ' AND ' must not be mistaken for a
+        condition separator, which would corrupt lower-level filter extraction."""
+        # multiseed id_cols = ["experiment_id", "variant"]
+        # generation is lower-level; the experiment_id value itself contains ' AND '
+        conn = MockConnection([("treat AND control", 0)])
+        analysis_type = "multiseed"
+        duckdb_filter = [
+            ("experiment_id", "experiment_id = 'treat AND control'"),
+            ("variant", "variant = 0"),
+            ("generation", "generation = 5"),
+        ]
+
+        query_strings = build_query_strings(
+            analysis_type,
+            duckdb_filter,
+            "SELECT * FROM config",
+            "SELECT * FROM history",
+            "SELECT * FROM success",
+            str(tmp_path),
+            conn,
+        )
+
+        assert len(query_strings) == 1
+        history_q, config_q, success_q, _, _ = next(iter(query_strings.values()))
+        for sql in (history_q, config_q, success_q):
+            # The lower-level filter must be exactly the generation condition
+            assert "generation = 5" in sql
+            # The experiment_id value must be preserved intact
+            assert "experiment_id='treat AND control'" in sql
+            # The 'AND control' fragment must NOT appear as a spurious bare condition
+            assert sql.count("control") == 1
 
 
 class TestIntegration:
@@ -731,7 +776,10 @@ class TestIntegration:
 
         # Build filter
         duckdb_filter = build_duckdb_filter(config)
-        assert "experiment_id = 'test_exp' AND variant IN (0, 1)" == duckdb_filter
+        assert duckdb_filter == [
+            ("experiment_id", "experiment_id = 'test_exp'"),
+            ("variant", "variant IN (0, 1)"),
+        ]
 
         # Load metadata
         v_metadata, sim_data_dict, v_names = load_variant_metadata(config)
@@ -795,7 +843,7 @@ class TestRunAnalysisLoop:
             "SELECT * FROM history",
             "SELECT * FROM config",
             "SELECT * FROM success",
-            "experiment_id = 'test_exp'",
+            [("experiment_id", "experiment_id = 'test_exp'")],
             variant_metadata,
             sim_data_dict,
             variant_names,
@@ -828,7 +876,7 @@ class TestRunAnalysisLoop:
             "SELECT * FROM history",
             "SELECT * FROM config",
             "SELECT * FROM success",
-            "",
+            [],
             {},
             {},
             {},
@@ -857,7 +905,7 @@ class TestRunAnalysisLoop:
                 "SELECT * FROM history",
                 "SELECT * FROM config",
                 "SELECT * FROM success",
-                "",
+                [],
                 {},
                 {},
                 {},
@@ -887,7 +935,7 @@ class TestRunAnalysisLoop:
             "SELECT * FROM history",
             "SELECT * FROM config",
             "SELECT * FROM success",
-            "",
+            [],
             {},
             {},
             {},
@@ -929,7 +977,7 @@ class TestRunAnalysisLoop:
             "SELECT * FROM history",
             "SELECT * FROM config",
             "SELECT * FROM success",
-            "",
+            [],
             {},
             {},
             {},
@@ -1007,7 +1055,7 @@ class TestRunAnalysisLoop:
             "SELECT * FROM history",
             "SELECT * FROM config",
             "SELECT * FROM success",
-            "",
+            [],
             variant_metadata,
             sim_data_dict,
             variant_names,
@@ -1051,7 +1099,7 @@ def test_exit_code_propagation(monkeypatch, tmp_path):
         "SELECT * FROM history",
         "SELECT * FROM config",
         "SELECT * FROM success",
-        "experiment_id = 'test_exp'",
+        [("experiment_id", "experiment_id = 'test_exp'")],
         {},
         {},
         {},

--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -1084,11 +1084,13 @@ def run_ecr_script(image: str, build: bool, region: str = "us-gov-west-1") -> st
     # or just <repo>:<tag> (script will create full URI)
     is_full_ecr_uri = False
     if "/" in image:
-        # Extract hostname from URI (part before first /)
-        hostname = image.split("/")[0]
-        # Verify hostname actually ends with .amazonaws.com to prevent
-        # bypass via URLs like evil.com/.amazonaws.com/path
-        is_full_ecr_uri = hostname.endswith(".amazonaws.com")
+        # Extract hostname from URI
+        parsed = parse.urlparse(image if "://" in image else f"//{image}")
+        hostname = (parsed.hostname or "").lower()
+        # Accept only amazonaws.com or its real subdomains
+        is_full_ecr_uri = hostname == "amazonaws.com" or hostname.endswith(
+            ".amazonaws.com"
+        )
 
     if is_full_ecr_uri:
         # Full URI provided, extract repo:tag
@@ -1319,8 +1321,6 @@ def stream_log(
                     print(new_content, end="", flush=True)
                 # Remember where we are now
                 last_position = f.tell()
-        else:
-            break
         if stop_event is not None and stop_event.is_set():
             break
         time.sleep(sleep_time)

--- a/uv.lock
+++ b/uv.lock
@@ -354,19 +354,18 @@ wheels = [
 
 [[package]]
 name = "biopython"
-version = "1.85"
+version = "1.87"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/ca/1d5fab0fedaf5c2f376d9746d447cdce04241c433602c3861693361ce54c/biopython-1.85.tar.gz", hash = "sha256:5dafab74059de4e78f49f6b5684eddae6e7ce46f09cfa059c1d1339e8b1ea0a6", size = 19909902, upload-time = "2025-01-15T15:06:51.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/3e/3c6aa8b2a7e6b791a34407736db32f59657001f0446ada31db73a3e0b7d5/biopython-1.87.tar.gz", hash = "sha256:8456c803459b679a9712422e5a7fd9809f2f089bf69bb085f3b077946ac9bdbf", size = 19855264, upload-time = "2026-03-30T11:28:29.823Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/25/e46f05359df7f0049c3adc5eaeb9aee0f5fbde1d959d05c78eb1de8f4d12/biopython-1.85-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cc5b981b9e3060db7c355b6145dfe3ce0b6572e1601b31211f6d742b10543874", size = 2789327, upload-time = "2025-01-15T15:13:17.086Z" },
-    { url = "https://files.pythonhosted.org/packages/54/5b/8b3b029c94c63ab4c1781d141615b4a837e658422381d460c5573d5d8262/biopython-1.85-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe47d704c2d3afac99aeb461219ec5f00273120d2d99835dc0a9a617f520141", size = 2765805, upload-time = "2025-01-15T15:13:26.92Z" },
-    { url = "https://files.pythonhosted.org/packages/69/0a/9a8a38eff03c4607b9cec8d0e08c76b346b1cee1f77bc6d00efebfc7ec83/biopython-1.85-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e54e495239e623660ad367498c2f7a1a294b1997ba603f2ceafb36fd18f0eba6", size = 3249276, upload-time = "2025-01-15T15:13:36.639Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/0d/b7a0f10f5100dcf51ae36ba31490169bfa45617323bd82af43e1fb0098fb/biopython-1.85-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d024ad48997ad53d53a77da24b072aaba8a550bd816af8f2e7e606a9918a3b43", size = 3268869, upload-time = "2025-01-15T15:13:44.009Z" },
-    { url = "https://files.pythonhosted.org/packages/07/51/646a4b7bdb4c1153786a70d33588ed09178bfcdda0542dfdc976294f4312/biopython-1.85-cp312-cp312-win32.whl", hash = "sha256:6985e17a2911defcbd30275a12f5ed5de2765e4bc91a60439740d572fdbfdf43", size = 2787011, upload-time = "2025-01-15T15:13:48.958Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/84/c583fa2ac6e7d392d24ebdc5c99e95e517507de22cf143efb6cf1fc93ff5/biopython-1.85-cp312-cp312-win_amd64.whl", hash = "sha256:d6f8efb2db03f2ec115c5e8c764dbadf635e0c9ecd4c0e91fc8216c1b62f85f5", size = 2820972, upload-time = "2025-01-15T15:13:54.475Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/18f024658c364196b7f9519674edd3233136fa19874b7ffd9e55ea0fd8e6/biopython-1.87-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:77ccc634621904d4a8fa0a43b5e0f093fa9df8c9577ed3858af648bb3528f51e", size = 2680980, upload-time = "2026-03-30T11:37:58.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/40/37c45bb4b5e345664bd970c3294349d1e35d4ad5794f808324bbef6ff9e7/biopython-1.87-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3428155c3e0abbed7aad5ff08e034d435b84dfe560c8ec58e7d43abda4b6a43", size = 3220352, upload-time = "2026-03-30T11:38:03.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/28/7898c2061966d6d62f0bb2e53cd5e1b3bb3053d2bc431f299802faca23cc/biopython-1.87-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:65ba69ef0273e983a9036c2a228142bc34266179a5f03660fc281d332d718630", size = 3246483, upload-time = "2026-03-30T11:38:07.185Z" },
+    { url = "https://files.pythonhosted.org/packages/54/d3/a594c8443dc8979b3c051aa266aa4af2d39762c4bb2c37fe6892a19a7713/biopython-1.87-cp312-cp312-win32.whl", hash = "sha256:b077777fd2c555434bdcee58743f6f860aa80e1e005d9671913aa73823c6a773", size = 2709063, upload-time = "2026-03-30T11:38:13.53Z" },
+    { url = "https://files.pythonhosted.org/packages/96/1a/d5884c67b20d9ae2b8d93593c971363421fd04c3dc8f5c35530c18e1d6a7/biopython-1.87-cp312-cp312-win_amd64.whl", hash = "sha256:856e3d64f1f27db493474ff84916ed8572731a525e001c7d0d8f41a0fd187000", size = 2743967, upload-time = "2026-03-30T11:38:10.739Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Before this PR, lower-level filters were being silently ignored by higher-level analyses. For example, the `generation`, `generation_range`, and `agent_id` options did nothing when running anything higher level than a multidaughter analysis (multigeneration, multiseed, multivariant, multiexperiment). This PR updates `runscripts/analysis.py` to fix that and adds tests in `runscripts/test_analysis_comprehensive.py`.

Other fixes (mainly addressing [these AI suggestions](https://github.com/CovertLab/vEcoli/security/quality/ai-findings)):
- Refactor memory and time scaling logic into reusable functions in `runscripts/nextflow/config.template`
- Document differences from Dockerfile and run apt clean up commands in Singularity image definition
- Extract ECR hostname using `urlparse` instead of custom string parsing
- Clean up docstring of transcript elongation process
- Update Biopython to 1.87 to fix https://github.com/advisories/GHSA-x3vf-39hj-gxr4