### PR TITLE
add documentation for dependencies and container image size

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -218,6 +218,26 @@ Always use ``uv`` commands to modify dependencies rather than editing
 ``uv.lock`` is updated, uv commands like ``uv run`` will automatically
 sync the environment to match the locked versions.
 
+Base versus Dev Dependencies
+---------------
+We manage two different sets of dependencies: **base** (runtime) and **dev**
+(development-only). Base dependencies are installed in production container
+images and are required to run simulations and workflows. Dev dependencies
+include more testing, interactive tools like Jupyter; they are installed
+only for local development.
+
+.. note::
+    **base** and **dev** are intentionally kept separate in considerations
+    of container image sizes and build time.
+
+It is common that local ``uv.lock`` and ``pyproject.toml`` get modified. Do
+not include unrelated lockfile changes in PRs unless you have considered the
+following. Before adding a dependency, decide which group it belongs in. Add to
+**base** only if the package is needed to run the model or shared production tooling.
+Add to **dev** if it is only needed for tests, linting, interactive notebooks,
+or other local development. Packages used solely in personal analysis notebooks
+generally should not be added to the project dependencies.
+
 Running Scripts
 ---------------
 


### PR DESCRIPTION
Add guidance to the contributing docs on when to add dependencies as base vs dev packages in `uv`. Base dependencies are installed in production container images, so dev-only tools (e.g. Jupyter and ipykernel) belong in the optional `dev` group to avoid unnecessary image size and build time. The new section clarifies that `pyproject.toml` and `uv.lock` should only be updated when intentionally adding or upgrading a project dependency.