### PR TITLE
Fix docker/scout-action PR comment exceeding GitHub's 65536-char body limit

### DIFF
--- a/.github/workflows/docker_security.yml
+++ b/.github/workflows/docker_security.yml
@@ -59,6 +59,8 @@ jobs:
           image: vecoli:latest
           sarif-file: sarif.output.json
           summary: true
+          only-severities: critical,high,medium
+          only-fixed: true
 
       - name: Upload SARIF result
         id: upload-sarif


### PR DESCRIPTION
`docker/scout-action` defaults to `write-comment: true` and posts the full JSON CVE report as a PR comment, sometimes exceeding GitHub's 65,536-character limit and failing with a `422 Validation Failed` error.

Added `only-severities: critical,high,medium` and `only-fixed: true` to the scout action step, scoping the PR comment to only critical/high/medium CVEs that have an available fix — the most actionable subset and a fraction of the original output size.

Full CVE data for all severities is still captured in `sarif.output.json` and uploaded to the GitHub Security tab.