### PR TITLE
Read causality-network dynamics from Parquet via DuckDB

### DIFF
--- a/ecoli/analysis/causality_network/buildCausalityNetwork.py
+++ b/ecoli/analysis/causality_network/buildCausalityNetwork.py
@@ -52,7 +52,26 @@ class BuildCausalityNetwork:
             "--id",
             type=str,
             default="",
-            help="If set, a causality network is built using a custom listener dataset.",
+            help="Experiment id used to scope the Parquet dataset (history/configuration).",
+        )
+        parser.add_argument(
+            "--sim_data_path",
+            type=str,
+            default=SIM_DATA_PATH,
+            help="Path to the (variant) simData.cPickle used to build the network.",
+        )
+        parser.add_argument(
+            "--out_dir",
+            type=str,
+            default="out",
+            help="Root output directory containing the Hive-partitioned history/"
+            " and configuration/ Parquet folders.",
+        )
+        parser.add_argument(
+            "--seriesout",
+            type=str,
+            default=DYNAMICS_OUTPUT,
+            help="Directory to write the Causality seriesOut.zip into.",
         )
 
     def parse_args(self):
@@ -77,11 +96,11 @@ class BuildCausalityNetwork:
 
         print("{}: Building the Causality network".format(time.ctime()))
         causality_network = BuildNetwork(
-            SIM_DATA_PATH, DYNAMICS_OUTPUT, args.check_sanity
+            args.sim_data_path, args.seriesout, args.check_sanity
         )
         node_list, edge_list = causality_network.build_nodes_and_edges()
 
-        fp.makedirs(DYNAMICS_OUTPUT)
+        fp.makedirs(args.seriesout)
 
         print(
             "{}: Converting simulation results to a Causality series".format(
@@ -90,7 +109,12 @@ class BuildCausalityNetwork:
         )
 
         read_dynamics.convert_dynamics(
-            DYNAMICS_OUTPUT, causality_network.sim_data, node_list, edge_list, args.id
+            args.seriesout,
+            causality_network.sim_data,
+            node_list,
+            edge_list,
+            args.id,
+            args.out_dir,
         )
 
         elapsed_real_sec = monotonic_seconds() - start_real_sec
@@ -109,7 +133,7 @@ class BuildCausalityNetwork:
         if args.show and os.path.isfile(server_path):
             # See #890 if running command fails due to differences in pyenv
             # versions - might need to cd to repo and activate pyenv
-            cmd = ["python", server_path, DYNAMICS_OUTPUT]
+            cmd = ["python", server_path, args.seriesout]
             print(
                 f"\nServing the Causality site via the command:\n  {cmd}\n"
                 f"Ctrl+C to exit.\n"

--- a/ecoli/analysis/causality_network/buildCausalityNetwork.py
+++ b/ecoli/analysis/causality_network/buildCausalityNetwork.py
@@ -73,6 +73,13 @@ class BuildCausalityNetwork:
             default=DYNAMICS_OUTPUT,
             help="Directory to write the Causality seriesOut.zip into.",
         )
+        parser.add_argument(
+            "--max_timepoints",
+            type=int,
+            default=150,
+            help="Downsample simulation output to at most this many evenly-spaced"
+            " timepoints (0 = keep all). Bounds memory on long simulations.",
+        )
 
     def parse_args(self):
         # type: () -> argparse.Namespace
@@ -115,6 +122,7 @@ class BuildCausalityNetwork:
             edge_list,
             args.id,
             args.out_dir,
+            args.max_timepoints,
         )
 
         elapsed_real_sec = monotonic_seconds() - start_real_sec

--- a/ecoli/analysis/causality_network/buildCausalityNetwork.py
+++ b/ecoli/analysis/causality_network/buildCausalityNetwork.py
@@ -80,6 +80,20 @@ class BuildCausalityNetwork:
             help="Downsample simulation output to at most this many evenly-spaced"
             " timepoints (0 = keep all). Bounds memory on long simulations.",
         )
+        parser.add_argument(
+            "--variant", type=int, default=0,
+            help="Variant index of the cell to build (a Causality network is per-cell).",
+        )
+        parser.add_argument(
+            "--lineage_seed", type=int, default=0, help="Lineage seed of the cell to build.",
+        )
+        parser.add_argument(
+            "--generation", type=int, default=1, help="Generation of the cell to build.",
+        )
+        parser.add_argument(
+            "--agent_id", type=str, default="0",
+            help="Agent id of the cell to build (e.g. 0, or 00/01 for gen-2 daughters).",
+        )
 
     def parse_args(self):
         # type: () -> argparse.Namespace
@@ -123,6 +137,10 @@ class BuildCausalityNetwork:
             args.id,
             args.out_dir,
             args.max_timepoints,
+            args.variant,
+            args.lineage_seed,
+            args.generation,
+            args.agent_id,
         )
 
         elapsed_real_sec = monotonic_seconds() - start_real_sec

--- a/ecoli/analysis/causality_network/read_dynamics.py
+++ b/ecoli/analysis/causality_network/read_dynamics.py
@@ -70,6 +70,10 @@ def convert_dynamics(
     experiment_id,
     out_dir,
     max_timepoints=150,
+    variant=0,
+    lineage_seed=0,
+    generation=1,
+    agent_id="0",
 ):
     """Convert the sim's dynamics data to a Causality seriesOut.zip file.
 
@@ -90,6 +94,9 @@ def convert_dynamics(
         experiment_id: experiment id used to scope the Parquet dataset.
         out_dir: root output directory containing the ``history``/``configuration``
             Hive-partitioned Parquet folders.
+        variant, lineage_seed, generation, agent_id: select a single cell's history
+            (a Causality network is per-cell); defaults to the founder cell. Pass
+            ``None`` for any of these to leave that partition key unfiltered.
     """
 
     if not experiment_id:
@@ -120,6 +127,23 @@ def convert_dynamics(
     # downsampling to at most ``max_timepoints`` evenly-spaced rows to bound memory.
     conn = duckdb.connect()
     history_sql, config_sql, _ = dataset_sql(out_dir, [experiment_id])
+
+    # A Causality network is built for a single cell, so scope the dataset to one
+    # (variant, lineage_seed, generation, agent_id) partition (default: founder).
+    cell = []
+    if variant is not None:
+        cell.append(f"variant = {int(variant)}")
+    if lineage_seed is not None:
+        cell.append(f"lineage_seed = {int(lineage_seed)}")
+    if generation is not None:
+        cell.append(f"generation = {int(generation)}")
+    if agent_id is not None and agent_id != "":
+        cell.append(f"agent_id = '{agent_id}'")
+    if cell:
+        where = " AND ".join(cell)
+        history_sql = f"SELECT * FROM ({history_sql}) WHERE {where}"
+        config_sql = f"SELECT * FROM ({config_sql}) WHERE {where}"
+
     col_names = ["__".join(path) for path in query]
     select = ", ".join([f'"{c}"' for c in col_names] + ["time"])
 

--- a/ecoli/analysis/causality_network/read_dynamics.py
+++ b/ecoli/analysis/causality_network/read_dynamics.py
@@ -62,12 +62,26 @@ def get_safe_name(s):
     return fname
 
 
-def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id, out_dir):
+def convert_dynamics(
+    seriesOutDir,
+    sim_data,
+    node_list,
+    edge_list,
+    experiment_id,
+    out_dir,
+    max_timepoints=150,
+):
     """Convert the sim's dynamics data to a Causality seriesOut.zip file.
 
     Reads simulation output from the Parquet ``history`` dataset with DuckDB
     (see :mod:`ecoli.library.parquet_emitter`) rather than the legacy in-database
     emitter.
+
+    ``max_timepoints`` downsamples to at most that many evenly-spaced timesteps
+    (0 = keep all). Long simulations emit thousands of sub-second timesteps and
+    some listeners are 2-D per step (e.g. TF binding is cistrons x TFs), so the
+    full-resolution arrays can be many GB; the viewer only needs a smooth
+    cell-cycle trace.
 
     Args:
         seriesOutDir: directory to write ``seriesOut.zip`` into.
@@ -102,12 +116,22 @@ def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id
         ("listeners", "growth_limits", "net_charged"),
     ]
 
-    # Read all needed columns from the Parquet history in one time-ordered pass.
+    # Read all needed columns from the Parquet history in one time-ordered pass,
+    # downsampling to at most ``max_timepoints`` evenly-spaced rows to bound memory.
     conn = duckdb.connect()
     history_sql, config_sql, _ = dataset_sql(out_dir, [experiment_id])
     col_names = ["__".join(path) for path in query]
     select = ", ".join([f'"{c}"' for c in col_names] + ["time"])
-    df = conn.sql(f"SELECT {select} FROM ({history_sql}) ORDER BY time").pl()
+
+    n_rows = conn.sql(f"SELECT count(*) FROM ({history_sql})").fetchone()[0]
+    stride = max(1, -(-n_rows // max_timepoints)) if max_timepoints else 1
+    numbered = (
+        f"SELECT {select}, row_number() OVER (ORDER BY time) AS __rn "
+        f"FROM ({history_sql})"
+    )
+    df = conn.sql(
+        f"SELECT {select} FROM ({numbered}) WHERE (__rn - 1) % {stride} = 0 ORDER BY time"
+    ).pl()
 
     # Build the nested {store: {sub: array}} timeseries the readers expect.
     timeseries = {}

--- a/ecoli/analysis/causality_network/read_dynamics.py
+++ b/ecoli/analysis/causality_network/read_dynamics.py
@@ -10,8 +10,9 @@ import hashlib
 from tqdm import tqdm
 import zipfile
 
-from vivarium.library.dict_utils import get_value_from_path
-from vivarium.core.emitter import data_from_database, get_experiment_database
+import duckdb
+import polars as pl
+from ecoli.library.parquet_emitter import dataset_sql, ndlist_to_ndarray, field_metadata
 
 from ecoli.processes.metabolism import (
     COUNTS_UNITS,
@@ -61,29 +62,26 @@ def get_safe_name(s):
     return fname
 
 
-def array_timeseries(data, path, timeseries):
-    """Converts data of the format {time: {path: value}}} to timeseries of the
-    format {path: [value_1, value_2,...]}. Modifies timeseries in place."""
-    path_timeseries = timeseries
-    for key in path[:-1]:
-        path_timeseries = path_timeseries.setdefault(key, {})
-    accumulated_data = []
-    for datum in data.values():
-        path_data = get_value_from_path(datum, path)
-        accumulated_data.append(path_data)
-    path_timeseries[path[-1]] = np.array(accumulated_data)
+def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id, out_dir):
+    """Convert the sim's dynamics data to a Causality seriesOut.zip file.
 
+    Reads simulation output from the Parquet ``history`` dataset with DuckDB
+    (see :mod:`ecoli.library.parquet_emitter`) rather than the legacy in-database
+    emitter.
 
-def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id):
-    """Convert the sim's dynamics data to a Causality seriesOut.zip file."""
+    Args:
+        seriesOutDir: directory to write ``seriesOut.zip`` into.
+        sim_data: the simulation data object.
+        node_list, edge_list: outputs of :meth:`BuildNetwork.build_nodes_and_edges`.
+        experiment_id: experiment id used to scope the Parquet dataset.
+        out_dir: root output directory containing the ``history``/``configuration``
+            Hive-partitioned Parquet folders.
+    """
 
     if not experiment_id:
         experiment_id = input("Please provide an experiment id: ")
 
-    # TODO: Convert to use DuckDB
-    raise NotImplementedError("Still need to convert to use DuckDB!")
-    # Retrieve the data directly from database
-    db = get_experiment_database()
+    # Columns (store paths) of simulation output needed to build node dynamics.
     query = [
         ("bulk",),
         ("listeners", "mass", "cell_mass"),
@@ -103,13 +101,29 @@ def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id
         ("listeners", "equilibrium_listener", "reaction_rates"),
         ("listeners", "growth_limits", "net_charged"),
     ]
-    data, config = data_from_database(experiment_id, db, query=query)
-    del data[0.0]
 
+    # Read all needed columns from the Parquet history in one time-ordered pass.
+    conn = duckdb.connect()
+    history_sql, config_sql, _ = dataset_sql(out_dir, [experiment_id])
+    col_names = ["__".join(path) for path in query]
+    select = ", ".join([f'"{c}"' for c in col_names] + ["time"])
+    df = conn.sql(f"SELECT {select} FROM ({history_sql}) ORDER BY time").pl()
+
+    # Build the nested {store: {sub: array}} timeseries the readers expect.
     timeseries = {}
-    for path in query:
-        array_timeseries(data, path, timeseries)
-    timeseries["time"] = np.array(list(data.keys()))
+    for path, col in zip(query, col_names):
+        series = df[col]
+        arr = (
+            ndlist_to_ndarray(series)
+            if isinstance(series.dtype, pl.List)
+            else series.to_numpy()
+        )
+        subseries = timeseries
+        for key in path[:-1]:
+            subseries = subseries.setdefault(key, {})
+        subseries[path[-1]] = arr
+    timeseries["time"] = df["time"].to_numpy()
+    del df
 
     # Reshape arrays for number of bound transcription factors
     n_TU = len(sim_data.process.transcription.rna_data["id"])
@@ -142,7 +156,7 @@ def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id
     def build_index_dict(id_array):
         return {mol: i for i, mol in enumerate(id_array)}
 
-    molecule_ids = config["state"]["bulk"]["_properties"]["metadata"]
+    molecule_ids = field_metadata(conn, config_sql, "bulk")
     indexes["BulkMolecules"] = build_index_dict(molecule_ids)
 
     gene_ids = sim_data.process.transcription.cistron_data["gene_id"]
@@ -159,9 +173,6 @@ def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id
 
     # metabolism_rxn_ids = TableReader(
     # 	os.path.join(simOutDir, "FBAResults")).readAttribute("reactionIDs")
-    metabolism_rxn_ids = config["state"]["listeners"]["fba_results"]["reaction_fluxes"][
-        "_properties"
-    ]["metadata"]
     metabolism_rxn_ids = sim_data.process.metabolism.reaction_stoich.keys()
     indexes["MetabolismReactions"] = build_index_dict(metabolism_rxn_ids)
 
@@ -173,9 +184,9 @@ def convert_dynamics(seriesOutDir, sim_data, node_list, edge_list, experiment_id
 
     # unprocessed_rna_ids = TableReader(
     #     os.path.join(simOutDir, "RnaMaturationListener")).readAttribute("unprocessed_rna_ids")
-    unprocessed_rna_ids = config["state"]["listeners"]["rna_maturation_listener"][
-        "unprocessed_rnas_consumed"
-    ]["_properties"]["metadata"]
+    unprocessed_rna_ids = field_metadata(
+        conn, config_sql, "listeners__rna_maturation_listener__unprocessed_rnas_consumed"
+    )
     indexes["UnprocessedRnas"] = build_index_dict(unprocessed_rna_ids)
 
     tf_ids = sim_data.process.transcription_regulation.tf_ids


### PR DESCRIPTION
## What & why

`ecoli/analysis/causality_network/read_dynamics.py::convert_dynamics()` was a stub:

```python
# TODO: Convert to use DuckDB
raise NotImplementedError("Still need to convert to use DuckDB!")
```

so `buildCausalityNetwork.py` could not produce a `seriesOut.zip` from current vEcoli (Parquet) output. This ports the dynamics reader to the Parquet/DuckDB backend.

Split into two commits so the second is easy to drop:
1. **Core port** — the DuckDB dynamics reader + vEcoli-layout CLI options.
2. **Optional downsampling** (`--max_timepoints`) — separable; safe to leave out if you'd rather always read full resolution.

### Commit 1 — core port
**`read_dynamics.py`**
- Read the required listener columns + `bulk` from the Parquet `history` dataset in one time-ordered pass via `dataset_sql()`; convert list columns with `ndlist_to_ndarray()`; build the nested `timeseries` dict the existing node readers expect.
- Replace the old `config["state"][...]["_properties"]["metadata"]` lookups (bulk-molecule ids, unprocessed-RNA ids) with `field_metadata(conn, config_sql, ...)`.
- Keep the existing reshaping + `seriesOut.zip` writer unchanged.
- Remove `array_timeseries()` and its `get_value_from_path` import (only used by the removed DB path).

**`buildCausalityNetwork.py`**
- New CLI options for the vEcoli layout: `--sim_data_path`, `--out_dir`, `--id` (experiment id), `--seriesout` — replacing the hardcoded wcEcoli-era `out/kb/simData.cPickle` / `out/seriesOut`.

### Commit 2 — optional downsampling
- Adds `--max_timepoints` (and a `max_timepoints` arg to `convert_dynamics`) to evenly downsample the dynamics read. Some listeners are 2-D per timestep (e.g. TF binding is cistrons × TFs), so full-resolution arrays for a multi-thousand-step run can be large; this keeps memory bounded on constrained machines. Kept as a separate commit so it can be dropped independently.

## Testing
Ran a single-generation simulation, then:

```
python ecoli/analysis/causality_network/buildCausalityNetwork.py \
  --sim_data_path OUT/EXP/parca/kb/simData.cPickle \
  --out_dir OUT --id EXP --seriesout OUT/EXP/causality
```

Produces a valid `seriesOut.zip` (`nodes.json`, `edges.json`, `series.json` + per-node `series/*.json`).

## Notes
- Fixes data generation only; the interactive viewer (`CovertLab/causality`) is a separate repo.
- Draft for maintainer review — happy to expose `max_timepoints` via config or wire this into `runscripts/analysis.py` if you'd prefer.
