### PR TITLE
Fix axs dims when show_enzyme_counts is false

### DIFF
--- a/ecoli/analysis/multigeneration/selected_fluxes.py
+++ b/ecoli/analysis/multigeneration/selected_fluxes.py
@@ -230,6 +230,8 @@ def plot(
         axs = np.array([axs])
     if n_rows == 1:
         axs = np.array([axs])
+    if axs.ndim != 2:
+        axs = axs[:, np.newaxis]
 
     # Group axes by what type of data we'll plot into them
     flux_axes = axs[:, 0]


### PR DESCRIPTION
Previously, the `selected_fluxes` analysis was failing when `show_enzyme_counts` was configured as `false`, because the dimensions of the matplotlib axis array weren't being handled properly in that case.

This PR introduces a small fix to address that issue.