### PR TITLE
Make Sherlock workflows reproducible

### DIFF
--- a/runscripts/container/singularity-env.sh
+++ b/runscripts/container/singularity-env.sh
@@ -11,3 +11,14 @@ export UV_TOOL_BIN_DIR="/vEcoli/.uv_tools/bin"
 export UV_PYTHON_INSTALL_DIR="/vEcoli/.uv_python"
 export UV_PYTHON_BIN_DIR="/vEcoli/.uv_python/bin"
 export UV_CACHE_DIR="/vEcoli/.uv_cache"
+
+# Pin BLAS/NumPy CPU code paths for cross-node reproducibility. Otherwise
+# OpenBLAS (bundled in the numpy/scipy wheels) runtime-dispatches a different
+# kernel per CPU model and NumPy's own SIMD reductions vary with AVX-512
+# availability, both of which change floating-point rounding across nodes.
+# x86-64 only: these names are invalid on aarch64 and would error, so there we
+# let OpenBLAS/NumPy autodetect. Respects any value set by the caller.
+if [ "$(uname -m)" = "x86_64" ]; then
+    export OPENBLAS_CORETYPE="${OPENBLAS_CORETYPE:-Haswell}"
+    export NPY_DISABLE_CPU_FEATURES="${NPY_DISABLE_CPU_FEATURES:-AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL AVX512_SPR}"
+fi


### PR DESCRIPTION
While we already [limit the types of CPUs](https://github.com/CovertLab/vEcoli/blob/b2078bd8e226c5d319bb9ddaa10a1f2f1fcfdbbc/runscripts/workflow.py#L108-L112) that vEcoli can use on Sherlock, these CPUs still differ in support for several key features and optimizations (most notably AVX-512). This results in unpredictable floating point variations that make workflows non-deterministic on Sherlock. This PR attempts to fix this by globally disabling these CPU features/optimizations, theoretically making them all behave identically.

This works in my limited testing, but further stress testing is necessary. Additionally, it would be nice to see exactly how much this hurts performance on platforms where all CPUs do support the latest features/optimizations (e.g., Carina, AWS).