### PR TITLE
Another idea for reproducibility on Sherlock

### DIFF
--- a/runscripts/workflow.py
+++ b/runscripts/workflow.py
@@ -109,7 +109,9 @@ CLUSTER_PRESETS: dict[str, dict[str, Any]] = {
             # See https://github.com/CovertLab/vEcoli/pull/331
             "CLUSTER_OPTIONS": {
                 "prefer": '"CPU_GEN:GEN|CPU_GEN:SPR"',
-                "constraint": '"CPU_GEN:RME|CPU_GEN:MLN|CPU_GEN:BGM|CPU_GEN:SIE|CPU_GEN:GEN|CPU_GEN:SPR"',
+                # Removed EPYC Rome and Milan as they do not support AVX-512,
+                # causing unpredictable floating point differences
+                "constraint": '"CPU_GEN:BGM|CPU_GEN:SIE|CPU_GEN:GEN|CPU_GEN:SPR"',
             },
             "QUEUE": "owners,normal",
         },


### PR DESCRIPTION
Instead of forcing all CPUs to conform to the lowest common denominator like in #443, another option is to simply drop support for older CPUs, as I did in this PR. The remaining CPU models all support the same AVX-512 features in NumPy and use the same SkylakeX kernel in OpenBLAS. That makes me hopeful that they will behave identically in our workflows, but **I have not tested that.**

Unlike #443, this approach only affects Sherlock and does not negatively impact performance on other platforms. The catch is that the two dropped CPU generations account for around 40% of all free CPUs supported before this PR (that percentage was calculated at the time of writing, free CPU counts are constantly changing). However, that still leaves several thousand eligible free CPU cores, so it's possible this doesn't affect job queue times at all.

Looking at the bigger picture, future CPUs will have even newer features that we cannot account for now. With that in mind, I think we should include CPU models in our publications so that future readers will always be able to reproduce our results by acquiring equivalent hardware.